### PR TITLE
Fix documentation builds

### DIFF
--- a/plugins/commands/documentation.py
+++ b/plugins/commands/documentation.py
@@ -54,30 +54,35 @@ INDEX_TEMPLATE = """
                    ])
 def command_build_documentation(incontext, options):
     documentation_directory = os.path.abspath(options.output)
-    
+
     with utils.Chdir(paths.SCRIPTS_DIR):
-        
+
         # Look up the python files to document.
-        files = glob.glob("*.py") + glob.glob("plugins/*.py")
+        files = utils.find(paths.SCRIPTS_DIR,
+                           extensions=[".py"],
+                           transform=lambda x: os.path.relpath(x, paths.SCRIPTS_DIR))
         modules = [os.path.splitext(f)[0] for f in files]
-        
+
         # Generate the Python documentation.
         for f in files:
             logging.info("Generating documentation for '%s'...", f)
             output_directory = os.path.join(documentation_directory, os.path.dirname(f))
             utils.makedirs(output_directory)
-            result = subprocess.run(["pdoc", 
+            environment = dict(os.environ)
+            environment["PYTHONPATH"] = paths.PLUGINS_DIR
+            result = subprocess.run(["pdoc",
                                      "--html",
                                      "--output-dir", output_directory,
                                      "--force",
                                      f],
-                                    capture_output=True)
+                                    capture_output=True,
+                                    env=environment)
             logging.debug(result.stdout)
             if result.returncode:
                 exit(result.stderr)
             elif result.stderr:
                 logging.warning(result.stderr)
-                              
+
         # Create an index page.
         with open(os.path.join(documentation_directory, "index.html"), "w") as fh:
             template = jinja2.Template(INDEX_TEMPLATE)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,9 +66,9 @@ class CommandsTestCase(unittest.TestCase):
 
     def test_build_documentation(self):
         with tempfile.TemporaryDirectory() as path:
-            self.assertEqual(len(os.listdir(path)), 0)
+            self.assertEqual(len(utils.find(path)), 0)
             common.run_incontext(["build-documentation", path], plugins_directory=paths.PLUGINS_DIR)
-            self.assertGreater(len(os.listdir(path)), 0)
+            self.assertEqual(len(utils.find(path)), 24)
 
     def test_add_draft_and_publish_with_build(self):
         configuration = {

--- a/utils.py
+++ b/utils.py
@@ -145,6 +145,24 @@ def find_files(path, types=None):
     return result
 
 
+def find(path, extensions=None, transform=None):
+    """
+    Find the files in `path` with file extensions matching `extensions`.
+
+    `extensions` should be given as an array of file extensions.
+
+    For example,
+
+    ```
+    texts = find("~/", [".txt"])
+    ```
+    """
+    paths = [os.path.join(*tripple) for tripple in find_files(path, types=extensions)]
+    if transform:
+        paths = [transform(path) for path in paths]
+    return paths
+
+
 def makedirs(path):
     """
     Ensure a directory exists at `path`, recursively creating all intermediate directories if necessary.


### PR DESCRIPTION
This fixes the issue where modules in the plugins subdirectories were being omitted from pdoc runs. It also makes the documentation build test stricter to try to avoid these issues in the future, and adds drive-by documentation and whitespace fixes.