### PR TITLE
Separate the remaining default handlers into separate modules

### DIFF
--- a/plugins/handlers/copy.py
+++ b/plugins/handlers/copy.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2016-2020 InSeven Limited
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import functools
+import os
+import shutil
+import utils
+
+
+def initialize_plugin(incontext):
+    incontext.add_handler("copy_file", copy_file)
+
+
+def copy_file(incontext, from_directory, to_directory):
+    @functools.wraps(copy_file)
+    def inner(path):
+        root, dirname, basename = utils.tripple(from_directory, path)
+        destination = os.path.join(to_directory, dirname, basename)
+        utils.makedirs(os.path.join(to_directory, dirname))
+        shutil.copy(path, destination)
+        return {'files': [destination]}
+    return inner

--- a/plugins/handlers/ignore.py
+++ b/plugins/handlers/ignore.py
@@ -19,29 +19,14 @@
 # SOFTWARE.
 
 import functools
-import os
-import shutil
-import utils
 
 
 def initialize_plugin(incontext):
     incontext.add_handler("ignore", ignore)
-    incontext.add_handler("copy_file", copy_file)
 
 
 def ignore(incontext, from_directory, to_directory):
     @functools.wraps(ignore)
     def inner(path):
         return {'files': []}
-    return inner
-
-
-def copy_file(incontext, from_directory, to_directory):
-    @functools.wraps(copy_file)
-    def inner(path):
-        root, dirname, basename = utils.tripple(from_directory, path)
-        destination = os.path.join(to_directory, dirname, basename)
-        utils.makedirs(os.path.join(to_directory, dirname))
-        shutil.copy(path, destination)
-        return {'files': [destination]}
     return inner

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,7 +68,7 @@ class CommandsTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as path:
             self.assertEqual(len(utils.find(path)), 0)
             common.run_incontext(["build-documentation", path], plugins_directory=paths.PLUGINS_DIR)
-            self.assertEqual(len(utils.find(path)), 24)
+            self.assertEqual(len(utils.find(path)), 25)
 
     def test_add_draft_and_publish_with_build(self):
         configuration = {
@@ -171,3 +171,37 @@ class CommandsTestCase(unittest.TestCase):
             site.assertExists("build/files/foo.txt")
             site.assertExists("build/files/image.jpeg")
             site.assertNotExists("build/files/example.markdown")
+
+    def test_ignore(self):
+        configuration = {
+            "config": {
+                "title": "Example Site",
+                "url": "https://example.com"
+            },
+            "paths": {},
+            "build_steps": [
+                {
+                    "task": "process_files",
+                    "args": {
+                        "handlers": [
+                            {
+                                "when": [
+                                    ".*\.txt",
+                                ],
+                                "then": "ignore",
+                            },
+                            {
+                                "when": [
+                                    ".*\.txt",
+                                ],
+                                "then": "copy_file",
+                            }
+                        ],
+                    }
+                },
+            ],
+        }
+        with common.TemporarySite(self, configuration=configuration) as site:
+            site.touch("content/foo.txt")
+            site.build()
+            site.assertNotExists("build/files/foo.txt")


### PR DESCRIPTION
This change moves the ignore and copy handlers into separate files and introduces a test for the ignore handler.