### PR TITLE
Add a command to create a new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Most existing static site generators do a great job with text content, but treat
 ## Getting Started
 
 ```bash
+incontext new my-new-site
+cd my-new-site
 incontext build
 ```
 

--- a/plugins/commands/new.py
+++ b/plugins/commands/new.py
@@ -40,4 +40,5 @@ def command_tests(incontext, options):
                                path])
         logging.info("Creating '%s'...", options.path)
         shutil.rmtree(os.path.join(path, ".git"))
+        shutil.rmtree(os.path.join(path, ".github"))
         shutil.copytree(path, os.path.abspath(options.path))

--- a/plugins/commands/new.py
+++ b/plugins/commands/new.py
@@ -20,18 +20,24 @@
 
 import logging
 import os
+import shutil
 import subprocess
+import tempfile
 
 import incontext
-import paths
 
 
-@incontext.command("tests", help="Run the tests")
+@incontext.command("new", help="Create a new site", arguments=[
+    incontext.Argument("path", help="destination of the new site")
+])
 def command_tests(incontext, options):
-    environment = dict(os.environ)
-    environment["PYTHONPATH"] = paths.INCONTEXT_DIRECTORY
-    try:
-        subprocess.check_call(["nosetests", "-v", paths.TESTS_DIR], env=environment)
-    except subprocess.CalledProcessError:
-        logging.error("Test run failed.")
-        exit(1)
+    print(os.path.abspath(options.site))
+    with tempfile.TemporaryDirectory() as path:
+        logging.info("Cloning site...")
+        subprocess.check_call(["git", "clone",
+                               "--depth", "1",
+                               "https://github.com/inseven/incontext-starter-site.git",
+                               path])
+        logging.info("Creating '%s'...", options.path)
+        shutil.rmtree(os.path.join(path, ".git"))
+        shutil.copytree(path, os.path.abspath(options.path))

--- a/plugins/manage.py
+++ b/plugins/manage.py
@@ -176,7 +176,7 @@ CONTENT_TYPES = {
 def command_add(incontext, parser):
     subparsers = parser.add_subparsers(title="content type", required=True)
     for content_type, function in CONTENT_TYPES.items():
-        parser = subparsers.add_parser(content_type, help=help)
+        parser = subparsers.add_parser(content_type)
         parser.set_defaults(add_function=function(incontext, parser))
 
     def add(options):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -209,7 +209,9 @@ class CommandsTestCase(unittest.TestCase):
     @common.with_temporary_directory
     def test_new_site(self):
         common.run_incontext(["new", "example"], plugins_directory=paths.PLUGINS_DIR)
-        self.assertTrue(os.path.exists(os.path.join("example/README.md")))
         site = common.Site(self, "example")
+        site.assertExists("README.md")
+        site.assertNotExists(".git")
+        site.assertNotExists(".github")
         site.build()
         site.assertExists("build/files/index.html")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,7 +68,7 @@ class CommandsTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as path:
             self.assertEqual(len(utils.find(path)), 0)
             common.run_incontext(["build-documentation", path], plugins_directory=paths.PLUGINS_DIR)
-            self.assertEqual(len(utils.find(path)), 25)
+            self.assertEqual(len(utils.find(path)), 26)
 
     def test_add_draft_and_publish_with_build(self):
         configuration = {
@@ -205,3 +205,11 @@ class CommandsTestCase(unittest.TestCase):
             site.touch("content/foo.txt")
             site.build()
             site.assertNotExists("build/files/foo.txt")
+
+    @common.with_temporary_directory
+    def test_new_site(self):
+        common.run_incontext(["new", "example"], plugins_directory=paths.PLUGINS_DIR)
+        self.assertTrue(os.path.exists(os.path.join("example/README.md")))
+        site = common.Site(self, "example")
+        site.build()
+        site.assertExists("build/files/index.html")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -42,6 +42,7 @@ class PluginsTestCase(unittest.TestCase):
                                  "build",
                                  "build-documentation",
                                  "clean",
+                                 "new",
                                  "publish",
                                  "tests",
                                  "watch",


### PR DESCRIPTION
This includes the following drive-by fixes:

- fix command line argument handling in the ‘add’ command
- remove unnecessary callstack on test failure