### PR TITLE
Add support for a generic extension which will load a template and pages it arguments

### DIFF
--- a/service/website.py
+++ b/service/website.py
@@ -96,6 +96,7 @@ def initialize(templates_path, store_path, config):
     app.jinja_env.add_extension('extensions.Gallery')
     app.jinja_env.add_extension('extensions.STL')
     app.jinja_env.add_extension('extensions.Video')
+    app.jinja_env.add_extension('extensions.TemplateExtension')
 
 
 def directory_mtime(path):
@@ -298,6 +299,13 @@ class DocumentWrapper(object):
             exit("Unknown query '%s'." % (identifier, ))
         return self._record_query(parameters)
 
+    def abspath(self, path):
+        if path == '.':
+            return self.url
+        if not path.startswith("/"):
+            return self.url + path
+        return path
+
     @property
     def content(self):
         if self._document["content"]:
@@ -407,7 +415,7 @@ class DefaultAttributeWrapper(object):
         self.wrapped = wrapped
         self.name = name
         self.value = value
-        
+
     def __getitem__(self, key):
         return self.__getattr__(key)
 


### PR DESCRIPTION
The goal of this is to replace the existing hard coded template-based extensions (`video`, `stl`, `gallery`, ...etc) with a lightweight approach that allows sites to safely their own templates in content.

Implementing this required digging into Jinja's templating and extensions a little further and it does seem like there might be alternative approaches (e.g., macros), but this is a reasonably flexible generic solution that can be used for the time being and allows special-case code to be removed from InContext.

This change includes the drive-by addition of a `abspath` method on `website.DocumentWrapper` to allow sites to easily replicate the functionality of things like the gallery extension which should support relative paths.