### PR TITLE
Remove the legacy dedicated STL extension

### DIFF
--- a/service/extensions.py
+++ b/service/extensions.py
@@ -70,19 +70,6 @@ class Video(SimpleExtension):
                                video=self.environment.store.get(url))
 
 
-class STL(SimpleExtension):
-
-    tags = set(['stl'])
-
-    def render(self, context, path, caller):
-        if not path.startswith("/"):
-            path = context["page"]["url"] + path
-        template = self.environment.get_template("extensions/stl.html")
-        return template.render(site=self.environment.site,
-                               path=path,
-                               uuid=str(uuid.uuid1()))
-
-
 class TemplateExtension(Extension):
 
     tags = {"template"}

--- a/service/website.py
+++ b/service/website.py
@@ -95,7 +95,6 @@ def initialize(templates_path, store_path, config):
     app.jinja_env.extend(store=store.DocumentStore(app.config["STORE_PATH"]))
 
     app.jinja_env.add_extension('extensions.Gallery')
-    app.jinja_env.add_extension('extensions.STL')
     app.jinja_env.add_extension('extensions.Video')
     app.jinja_env.add_extension('extensions.TemplateExtension')
 


### PR DESCRIPTION
The dedicated STL extension relies on user-provided templates and functionality can now be fully replicated with the new 'template' extension.