### PR TITLE
Remove the Nova configuration and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .sass-cache
 Pipfile.lock
 __pycache__
+.nova
+.venv

--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,3 +1,0 @@
-{
-  "workspace.color" : 0
-}


### PR DESCRIPTION
This also includes a drive-by fix to ignore .venv (which GitHub Codespaces seems to create).