### PR TITLE
Ensure that TIFF snapshots are converted to JEPGs

### DIFF
--- a/plugins/manage.py
+++ b/plugins/manage.py
@@ -98,8 +98,13 @@ def subcommand_add_snapshot(incontext, parser):
             basename, ext = os.path.splitext(filename)
             if ext.lower() == ".tiff":
                 logging.info("Converting TIFF to JPEG...")
+
                 jpeg_path = os.path.join(temporary_directory, f"{basename}.jpeg")
                 subprocess.check_call(["convert", path, "-quality", "100", jpeg_path])
+
+                # Unfortunately we also need to copy the metadata in a separate step.
+                subprocess.check_call(["exiftool", "-TagsFromFile", path, "-all:all>all:all", jpeg_path])
+
                 path = jpeg_path
 
             exif = gallery.Exif(path)


### PR DESCRIPTION
Unfortunately Photos.app still seems to have a bug whereby the Title EXIF key isn't set when exporting photos as JEPGs. It's still present for TIFF exports meaning this is currently the only way to get all the metadata out of Apple Photos. Since TIFF can be pretty unwieldy, this change introduces automatic conversion of TIFF shapshots to JPEG.