### PR TITLE
Move the GPS coordinate parsing into the EXIF schema

### DIFF
--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -45,7 +45,7 @@ import converters
 import store
 import utils
 
-from schema import Default, Dictionary, Empty, First, Key
+from schema import Default, Dictionary, Empty, First, GPSCoordinate, Key
 
 
 PRIORITIZED_DATE_KEYS = [
@@ -75,8 +75,8 @@ METADATA_SCHEMA = Dictionary({
     "date": First(Key("DateTimeOriginal"), Key("ContentCreateDate"), Key("CreationDate"), Empty()),
     "projection": First(Key("ProjectionType"), Empty()),
     "location": First(Dictionary({
-        "latitude": Key("GPSLatitude"),
-        "longitude": Key("GPSLongitude"),
+        "latitude": GPSCoordinate(Key("GPSLatitude")),
+        "longitude": GPSCoordinate(Key("GPSLongitude")),
     }), Empty())
 
 })
@@ -174,16 +174,6 @@ def exif(path):
     for field in PRIORITIZED_DATE_KEYS:
         if field in data:
             data[field] = dateutil.parser.parse(data[field].replace(":", "-", 2))
-
-    for field in ["GPSLatitude", "GPSLongitude"]:
-        if field in data:
-            components = data[field].split(" ")
-            value = float(components[0])
-            if len(components) > 1:
-                direction = components[1]
-                if direction == "W":
-                    value = value * -1
-            data[field] = value
 
     return data
 

--- a/schema.py
+++ b/schema.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import re
+
 
 class TransformFailure(Exception):
     pass
@@ -67,6 +69,32 @@ class Empty(object):
 
     def __call__(self, data):
         raise Skip()
+
+
+class Identity(object):
+
+    def __call__(self, data):
+        return data
+
+
+GPS_COORDINATE_EXPRESSION = re.compile(r"^(\d+\.\d+) ([NSEW])$")
+
+
+class GPSCoordinate(object):
+
+    def __init__(self, transform):
+        self.transform = transform
+
+    def __call__(self, data):
+        data = self.transform(data)
+        match = GPS_COORDINATE_EXPRESSION.match(data)
+        if not match:
+            raise AssertionError(f"Invalid GPS coordinate '{data}'.")
+        value = float(match.group(1))
+        direction = match.group(2)
+        if direction == "W":
+            value = value * -1
+        return value
 
 
 class Dictionary(object):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,7 +22,7 @@
 
 import unittest
 
-from schema import Dictionary, Empty, First, Key, Skip, TransformFailure
+from schema import Dictionary, Empty, First, GPSCoordinate, Identity, Key, Skip, TransformFailure
 
 
 class SchemaTestCase(unittest.TestCase):
@@ -80,3 +80,17 @@ class SchemaTestCase(unittest.TestCase):
             {"bar": "cheese"},
             {"foo": "cheese"}
         )
+
+    def test_identity(self):
+        s = Identity()
+        self.assertEqual(s("Hello, World!"), "Hello, World!")
+        self.assertEqual(s({}), {})
+
+    def test_gps_coordinate(self):
+        s = GPSCoordinate(Identity())
+        self.assertEqual(s("45.5283694444 N"), 45.5283694444)
+        self.assertEqual(s("45.5283694444 S"), 45.5283694444)
+        self.assertEqual(s("119.3941638889 W"), -119.3941638889)
+        self.assertEqual(s("119.3941638889 E"), 119.3941638889)
+        with self.assertRaises(AssertionError):
+            s("45 deg 31' 42.13\" N")


### PR DESCRIPTION
This change is another step-wise move towards centralised EXIF handling using the new schema mechanism by introducing a new GPSCoordinate transform which obviates the need for the pre-processing of coordinates. It also introduces some testing for coordinate parsing.