### PR TITLE
Use ImageMagick for more reliable HEIC image conversion and resizing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,16 +16,20 @@ RUN bash -c "cat docker/requirements.txt | xargs apt-get install -y"
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN dpkg-reconfigure --frontend noninteractive tzdata
 
+# Install ImageMagick
+WORKDIR ${INCONTEXT_DIR}/docker
+RUN bash install_imagemagick.sh
+
 # Unfortunately the ARM build of Ubuntu 20.04 doesn't seem to have a sufficiently up to date version of libhef, meaning
 # that the Python dependencies will fail to build. Instead, we download the source directly and compile it on both
 # ARM and Intel for consistency.
-WORKDIR /usr/local/src/
-RUN git clone https://github.com/strukturag/libheif.git --branch v1.9.1
-WORKDIR /usr/local/src/libheif
-RUN ./autogen.sh
-RUN ./configure
-RUN make
-RUN make install
+# WORKDIR /usr/local/src/
+# RUN git clone https://github.com/strukturag/libheif.git --branch v1.9.1
+# WORKDIR /usr/local/src/libheif
+# RUN ./autogen.sh
+# RUN ./configure
+# RUN make
+# RUN make install
 
 # Install the Python dependencies.
 WORKDIR ${INCONTEXT_DIR}/docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,20 +16,9 @@ RUN bash -c "cat docker/requirements.txt | xargs apt-get install -y"
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN dpkg-reconfigure --frontend noninteractive tzdata
 
-# Install ImageMagick
+# Install ImageMagick with HEIC support
 WORKDIR ${INCONTEXT_DIR}/docker
 RUN bash install_imagemagick.sh
-
-# Unfortunately the ARM build of Ubuntu 20.04 doesn't seem to have a sufficiently up to date version of libhef, meaning
-# that the Python dependencies will fail to build. Instead, we download the source directly and compile it on both
-# ARM and Intel for consistency.
-# WORKDIR /usr/local/src/
-# RUN git clone https://github.com/strukturag/libheif.git --branch v1.9.1
-# WORKDIR /usr/local/src/libheif
-# RUN ./autogen.sh
-# RUN ./configure
-# RUN make
-# RUN make install
 
 # Install the Python dependencies.
 WORKDIR ${INCONTEXT_DIR}/docker

--- a/docker/Pipfile
+++ b/docker/Pipfile
@@ -3,9 +3,9 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
-
 [packages]
 
+braceexpand = "*"
 Flask = "*"
 Flask-misaka = "*"
 Jinja2 = "*"
@@ -14,14 +14,13 @@ misaka = "*"
 nose = "*"
 pdoc3 = "*"
 Pillow = "*"
-python-dateutil = ">=2.7"
 pyheif = "*"
+python-dateutil = ">=2.7"
 python-frontmatter = "*"
 pytz = "*"
 titlecase = "*"
-whatimage = "*"
 watchdog = "*"
-
+whatimage = "*"
 
 [requires]
 

--- a/docker/install_imagemagick.sh
+++ b/docker/install_imagemagick.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+apt-get update
+apt-get install -y build-essential autoconf git-core wget
+apt-get build-dep -y imagemagick libde265 libheif
+cd /usr/src/
+git clone https://github.com/strukturag/libde265.git
+git clone https://github.com/strukturag/libheif.git
+cd libde265/
+./autogen.sh
+./configure
+make –j4
+make install
+cd /usr/src/libheif/
+./autogen.sh
+./configure
+make –j4
+make install
+cd /usr/src/
+wget https://www.imagemagick.org/download/ImageMagick.tar.gz
+tar xf ImageMagick.tar.gz
+cd ImageMagick-7*
+./configure --with-heic=yes
+make –j4
+make install
+ldconfig

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -6,7 +6,6 @@ exiftool
 ffmpeg
 gifsicle
 git
-imagemagick
 libde265-dev
 libheif-dev
 libtool

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -286,9 +286,6 @@ def safe_resize(source, destination, size):
 
     This makes use of `RESIZE_METHODS` to determine which resize handler to use.
     """
-
-
-
     resize_method = evaluate_tests(RESIZE_METHODS, os.path.basename(source))
     resize_method(source,
                   destination,

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -105,23 +105,6 @@ def generate_identifier(basename):
     return os.path.splitext(basename)[0]
 
 
-def load_metadata(path):
-
-    default = {"version": 0}
-    try:
-        fm = frontmatter.load(path)
-        dictionary = fm.metadata
-        try:
-            dictionary["content"] = fm.content
-        except AttributeError:
-            pass
-        return dictionary
-    except IOError:
-        return default
-    except ValueError:
-        return default
-
-
 def exif(path):
     data = json.loads(subprocess.check_output(["exiftool", "-j", "-c", "%.10f", path]).decode('utf-8'))[0]
 
@@ -296,7 +279,6 @@ RESIZE_METHODS = [
 ]
 
 
-# TODO: Move this into the user definition.
 OUTPUT_MIME_TYPES = [
     (Glob("*.heic"), "image/jpeg"),
     (Glob("*.tiff"), "image/jpeg"),
@@ -366,7 +348,7 @@ def resize(source, dest_root, dest_dirname, dest_basename, size, scale):
     return get_details(dest_root, dest_dirname, dest_basename, scale)
 
 
-# TODO: Remove this code.
+# TODO: Rename the generate_thumbnail method as it's misleading #45
 def generate_thumbnail(source, dest_root, dest_dirname, dest_basename, size, source_scale, scale):
     destination = os.path.join(dest_root, dest_dirname, dest_basename)
     return resize(source, dest_root, dest_dirname, dest_basename, size, scale)

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -290,65 +290,6 @@ class Glob(Or):
         super().__init__(*tests)
 
 
-# TODO: Do I need a magic marker for format=InputFormat?
-
-# TODO: Perhaps this is a subclass of Output, so that things like tags can be passed?
-class Resize(object):
-
-    def __init__(self, size=None, format=None):
-        self.format = format
-        self.size = size
-
-
-class And(object):
-
-    def __init__(self, *matches):
-        self.matches = matches
-
-
-# TODO: Move this out for the time being.
-class Metadata(object):
-
-    def __init__(self, xpath):
-        self.xpath = xpath
-
-    def evaluate(self, path, image, metadata):
-        return True
-
-
-class Output(object):
-
-    def __init__(self, transform, tag=None):
-        self.transform = transform
-        self.tag = tag
-
-
-# Ors are achieved by a list of options.
-# Ands would be achieved by a list in the opposite direction?
-
-
-# TODO: How do I express the main image? Or is it sufficient to match on size?
-
-# TODO: Images should be able to be put into a namespace.
-# TODO: Perhaps it's better to put multiple images into namespaces?
-
-
-# TODO: This is unused; consider removing it for the time being.
-OPERATIONS = [
-
-    (Glob("*.jpeg"),
-        Resize(Size(1600, None))),
-    (Glob("*.heic"),
-        Resize(Size(1600, None), format="image/jpeg"), # TODO: Tags??
-        Resize(Size(800, None), format="image/jpeg")),
-    (And(Glob("*.jpeg"), Metadata("[Projection=equirectangular]")),
-        Resize(Size(1600, None))),
-    (Glob("*"),
-        Resize(Size(1600, None))),
-
-]
-
-
 RESIZE_METHODS = [
     (Glob("*.gif"), gifsicle_resize),
     (Glob("*"), imagemagick_resize),
@@ -381,8 +322,6 @@ def safe_resize(source, destination, size):
                   destination,
                   f"{size.width}x{size.height}")
 
-# TODO: Test GIF
-
 
 # TODO: Make the API for this much cleaner.
 # It should simply have a source and a destination.
@@ -394,8 +333,6 @@ def resize(source, dest_root, dest_dirname, dest_basename, size, scale):
     destination_mime_type = evaluate_tests(OUTPUT_MIME_TYPES, os.path.basename(source))
     destination_extension = ext if destination_mime_type == "*" else mimetypes.guess_extension(destination_mime_type)
     dest_basename = f"{name}{destination_extension}"
-
-    # TODO: Add a test for TIFF conversion.
 
     # TODO: This is almost certainly inefficient.
     # TODO: Perhaps this should be moved into the resize method?

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -144,19 +144,6 @@ def load_image(path):
     return Image.open(path)
 
 
-def get_orientation(exif):
-    try:
-        exif = dict(exif.items())
-        for orientation in ExifTags.TAGS.keys():
-            if ExifTags.TAGS[orientation] == 'Orientation':
-                break
-        return exif[orientation]
-    except:
-        logging.debug("Unable to get get EXIF data")
-        pass
-    return 1
-
-
 def get_size(source, scale):
     with load_image(source) as img:
         width, height = img.size

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -341,12 +341,6 @@ def generate_thumbnail(source, dest_root, dest_dirname, dest_basename, size, sou
     return resize(source, dest_root, dest_dirname, dest_basename, size, scale)
 
 
-def get_image_data(root, dirname, basename):
-    with Image.open(os.path.join(root, dirname, basename)) as img:
-        width, height = img.size
-        return {"filename": basename, "width": width, "height": height}
-
-
 def metadata_from_exif(path):
     """
     Generate a metadata dictionary from just the EXIF data contained within the file at `path`, as specified within
@@ -375,15 +369,14 @@ def process_image(incontext, root, destination, dirname, basename, category, tit
     metadata = metadata_for_media_file(root, os.path.join(dirname, basename),
                                        title_from_filename=title_from_filename)
 
+    # TODO: Support specifying image size sets in the configuration file #10
+
     # Determine which profiles to use; we use a different profile for equirectangular projections.
-    # TODO: In an ideal world we would allow all of this special case behaviour to be configured in site.yaml
-    #       so there are no custom modifications required to the script.
     profiles = DEFAULT_PROFILES
     if "projection" in metadata and metadata["projection"] == "equirectangular":
         profiles = EQUIRECTANGULAR_PROFILES
 
     # Generate the various different image sizes.
-    # TODO: Consider making this common code for all images.
     for profile_name, profile_details in profiles.items():
 
         filename = "%s-%s%s" % (identifier, profile_name.replace("_", "-"), ext)

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -286,15 +286,15 @@ def safe_resize(source, destination, size):
 
     This makes use of `RESIZE_METHODS` to determine which resize handler to use.
     """
+
+
+
     resize_method = evaluate_tests(RESIZE_METHODS, os.path.basename(source))
     resize_method(source,
                   destination,
                   f"{size.width}x{size.height}")
 
 
-# TODO: Make the API for this much cleaner.
-# It should simply have a source and a destination.
-# TODO: Where should the destination extension be?
 def resize(source, dest_root, dest_dirname, dest_basename, size, scale):
 
     # Determine the desired output MIME type and extension.
@@ -303,13 +303,9 @@ def resize(source, dest_root, dest_dirname, dest_basename, size, scale):
     destination_extension = ext if destination_mime_type == "*" else mimetypes.guess_extension(destination_mime_type)
     dest_basename = f"{name}{destination_extension}"
 
-    # TODO: This is almost certainly inefficient.
-    # TODO: Perhaps this should be moved into the resize method?
     with load_image(source) as image:
         (source_width, source_height) = image.size
         logging.debug("Image source dimensions = %sx%s", source_width, source_height)
-
-        # TODO: Move this into a separate utility for testing.
 
         # Determine the target dimensions.
         source_ratio = source_width / source_height

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -214,7 +214,6 @@ def gifsicle_resize(source, destination, size):
         raise e
 
 
-# TODO: Use this.
 class Size(object):
 
     def __init__(self, width, height):

--- a/schema.py
+++ b/schema.py
@@ -108,6 +108,11 @@ class EXIFDate(object):
         data = self.transform(data)
         # ExifTool makes the odd decision to separate the date components with a colon, meaning that `dateutil` cannot
         # parse it directly, so we fix it up.
+
+        # Skip zero dates.
+        if data == "0000:00:00 00:00:00":
+            raise TransformFailure()
+
         value = dateutil.parser.parse(data.replace(":", "-", 2))
         return value
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,7 +68,7 @@ class CommandsTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as path:
             self.assertEqual(len(utils.find(path)), 0)
             common.run_incontext(["build-documentation", path], plugins_directory=paths.PLUGINS_DIR)
-            self.assertEqual(len(utils.find(path)), 29)
+            self.assertEqual(len(utils.find(path)), 30)
 
     def test_add_draft_and_publish_with_build(self):
         configuration = {

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -108,3 +108,5 @@ class GalleryTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(basename))
         output_size = gallery.get_size(basename, 1)
         self.assertEqual(output_size["width"], size[0])
+
+        # TODO: Test TIFF and GIF conversion

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -44,6 +44,7 @@ IMG_3857_HEIC = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3857.heic")
 IMG_3864_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3864.jpeg")
 IMG_3870_HEIC = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.heic")
 IMG_3870_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.jpeg")
+IMG_6218_TIFF = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_6218.tiff")
 
 
 class GalleryTestCase(unittest.TestCase):
@@ -92,6 +93,18 @@ class GalleryTestCase(unittest.TestCase):
         basename = os.path.basename(IMG_3870_HEIC)
         size = (1600, None)
         gallery.resize(IMG_3870_HEIC, os.getcwd(), "", basename, size, 1)
+
+        expected_basename = utils.replace_extension(basename, ".jpg")
+        self.assertTrue(os.path.exists(expected_basename))
+        output_size = gallery.get_size(expected_basename, 1)
+        self.assertEqual(output_size["width"], size[0])
+
+    @common.with_temporary_directory
+    def test_resize_tiff_with_format_change(self):
+
+        basename = os.path.basename(IMG_6218_TIFF)
+        size = (1600, None)
+        gallery.resize(IMG_6218_TIFF, os.getcwd(), "", basename, size, 1)
 
         expected_basename = utils.replace_extension(basename, ".jpg")
         self.assertTrue(os.path.exists(expected_basename))

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016-2021 InSeven Limited
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+import logging
+import os
+import unittest
+import subprocess
+import sys
+
+import paths
+
+sys.path.append(os.path.join(paths.PLUGINS_DIR, "handlers"))
+
+import gallery
+
+from gallery import Equal, Glob, Or, Regex
+
+
+IMG_3857_HEIC = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3857.heic")
+IMG_3864_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3864.jpeg")
+IMG_3870_HEIC = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.heic")
+IMG_3870_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.jpeg")
+
+
+class GalleryTestCase(unittest.TestCase):
+
+    def test_regex(self):
+        self.assertTrue(Regex(r".*").evaluate("a"))
+        self.assertTrue(Regex(r"hello").evaluate("hello"))
+        self.assertFalse(Regex(r"hello").evaluate("goodbye"))
+        self.assertTrue(Regex(r"hello").evaluate("hello world"))
+        self.assertFalse(Regex(r"^hello$").evaluate("hello world"))
+
+    def test_equal(self):
+        self.assertTrue(Equal(True).evaluate(True))
+        self.assertFalse(Equal(True).evaluate(False))
+        self.assertTrue(Equal(12).evaluate(12))
+        self.assertFalse(Equal(12).evaluate(13))
+        self.assertFalse(Equal(18).evaluate("cheese"))
+        self.assertTrue(Equal("cheese").evaluate("cheese"))
+        self.assertFalse(Equal("cheese").evaluate("fromage"))
+        self.assertFalse(Equal("cheese").evaluate(12))
+
+    def test_or(self):
+        self.assertTrue(Or(Equal(True)).evaluate(True))
+        self.assertTrue(Or(Equal(True), Equal(False)).evaluate(True))
+        self.assertTrue(Or(Equal(False), Equal(True)).evaluate(True))
+        self.assertFalse(Or(Equal(False), Equal(False)).evaluate(True))
+        self.assertTrue(Or(Equal(False), Equal(False)).evaluate(False))
+
+    def test_glob(self):
+        self.assertTrue(Glob("*.jpeg").evaluate("IMG_3875.jpeg"))
+        self.assertFalse(Glob("*.tiff").evaluate("IMG_3875.jpeg"))
+        self.assertTrue(Glob("*.{jpeg,tiff}").evaluate("IMG_3875.jpeg"))
+        self.assertTrue(Glob("*.{jpeg,tiff}").evaluate("IMG_3875.tiff"))
+
+    def test_get_size(self):
+
+        # TODO: Use a temporary directory.
+
+        destination_root = os.getcwd()
+        destination_dirname = ""
+        destination_basename = os.path.basename(IMG_3870_HEIC)
+        size = (1600, None)
+        scale = 1
+
+        gallery.resize(IMG_3870_HEIC, destination_root, destination_dirname, destination_basename, size, scale)
+
+        name, ext = os.path.splitext(destination_basename)
+        expected_basename = f"{name}.jpeg"
+        self.assertTrue(os.path.exists(expected_basename))
+
+        output_size = gallery.get_size(expected_basename, 1)
+        self.assertEqual(output_size["width"], size[0])
+
+        # TODO: Check that the image has the correct size.
+        # TODO: Check that the image is the correct type (not sure quite how we do this)?
+
+        # subprocess.check_call(["mogrify", "--version"])
+
+        # gallery.imagemagick_resize(IMG_3870_HEIC, "output.jpeg", "1600x1200")
+        # TODO: Assert that it created a file in the expected location.
+        # TODO: How do we check that the file is valid?

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -45,6 +45,7 @@ IMG_3864_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3864.jpeg")
 IMG_3870_HEIC = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.heic")
 IMG_3870_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_3870.jpeg")
 IMG_6218_TIFF = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/IMG_6218.tiff")
+PREVIEW_GIF = os.path.join(paths.TEST_DATA_DIRECTORY, "gallery/preview.gif")
 
 
 class GalleryTestCase(unittest.TestCase):
@@ -118,8 +119,20 @@ class GalleryTestCase(unittest.TestCase):
         size = (800, None)
         gallery.resize(IMG_3870_JPEG, os.getcwd(), "", basename, size, 1)
 
-        self.assertTrue(os.path.exists(basename))
+        self.assertTrue(os.path.exists(utils.replace_extension(basename, ".jpeg")))
         output_size = gallery.get_size(basename, 1)
         self.assertEqual(output_size["width"], size[0])
+
+    @common.with_temporary_directory
+    def test_resize_gif(self):
+
+        basename = os.path.basename(PREVIEW_GIF)
+        size = (200, None)
+        gallery.resize(PREVIEW_GIF, os.getcwd(), "", basename, size, 1)
+
+        self.assertTrue(os.path.exists(utils.replace_extension(basename, ".gif")))
+        output_size = gallery.get_size(basename, 1)
+        self.assertEqual(output_size["width"], size[0])
+
 
         # TODO: Test TIFF and GIF conversion

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -105,6 +105,7 @@ class SchemaTestCase(unittest.TestCase):
         s = EXIFDate(Identity())
         self.assertEquals(s("2019:10:20 12:14:09.606-07:00"), dateutil.parser.parse("2019-10-20 12:14:09.606-07:00"))
         self.assertEquals(s("2019:09:10 09:04:30"), dateutil.parser.parse("2019-09-10 09:04:30"))
+        self.assertIsNone(First(s, Default(None))("0000:00:00 00:00:00"))
 
     def test_date_transform_with_first(self):
         s = First(EXIFDate(First(Key("date"), Key("secondary_date"))), Default(None))

--- a/utils.py
+++ b/utils.py
@@ -212,3 +212,8 @@ def create_animated_thumbnail(input, output):
                                "-layers", "OptimizeTransparency",
                                "-colors", "256",
                                output])
+
+
+def replace_extension(path, extension):
+    root, ext = os.path.splitext(path)
+    return root + extension


### PR DESCRIPTION
In order to address an issue when resizing HEIC files (the stride of cropped HEIC images was incorrect), this change reverts to using ImageMagick as the primary path for converting and resizing images. In order to do this, the Docker image has been updated to use a source build of ImageMagick within HEIC support.

This change also makes some tentative steps towards a more declarative approach for specifying image thumbnail generation (see the most recent notes in (https://github.com/inseven/incontext/issues/10). It intoduces a new class (`Glob`) which can be used used to concisely represent and perform a filename glob match which can hopefully be used as the basis for a configuration-based modelling of transform operations.
