### PR TITLE
Clean up the metadata keys used to select dates

### DIFF
--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -55,7 +55,7 @@ METADATA_SCHEMA = Dictionary({
 
     "title": First(Key("Title"), Key("DisplayName"), Key("ObjectName"), Empty()),
     "content": First(Key("ImageDescription"), Key("Description"), Key("ArtworkContentDescription"), Default(None)),
-    "date": First(EXIFDate(First(Key("DateTimeOriginal"), Key("CreateDate"), Key("ContentCreateDate"), Key("CreationDate"), Key("FileModifyDate"))), Empty()),
+    "date": First(EXIFDate(First(Key("DateTimeOriginal"), Key("ContentCreateDate"), Key("CreationDate"))), Empty()),
     "projection": First(Key("ProjectionType"), Empty()),
     "location": First(Dictionary({
         "latitude": GPSCoordinate(Key("GPSLatitude")),


### PR DESCRIPTION
When reworking the metadata key selection logic, some additional keys were introduced to the data selection process. These incorrectly caused filesystem dates to be used when attempting to determine the relevant dates for both images and videos.