### PR TITLE
Support loading user-defined plugins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,5 @@ RUN bash install_imagemagick.sh
 
 # Install the Python dependencies.
 WORKDIR ${INCONTEXT_DIR}/docker
-# COPY Pipfile ${INCONTEXT_DIR}/
 RUN python3 -m pip install pipenv
 RUN pipenv install --verbose --system --skip-lock

--- a/incontext
+++ b/incontext
@@ -44,7 +44,7 @@ def get_files(path):
     for root, dirs, files in os.walk(path):
         result.extend(files)
     return result
-    
+
 
 def get_directory_sha(path):
     hash = hashlib.sha256()
@@ -53,8 +53,8 @@ def get_directory_sha(path):
         with open(os.path.join(path, f), 'rb') as fh:
             hash.update(fh.read())
     return hash.hexdigest()
-    
-    
+
+
 def unique_prefixes(paths):
     previous = None
     for path in sorted(paths):
@@ -62,8 +62,8 @@ def unique_prefixes(paths):
             continue
         previous = path
         yield previous
-        
-        
+
+
 def filter_paths(items):
     return [os.path.abspath(item) for item in items if os.path.exists(item)]
 
@@ -82,7 +82,7 @@ def main():
                 waiting = True
                 logging.info("Waiting for docker...")
             time.sleep(2)
-    
+
     # Check to see if we already have a suitable docker image; build one if not.
     # This generates a SHA for the docker directory and uses this as a tag to identify the required docker image.
     directory_sha = get_directory_sha(DOCKER_DIRECTORY)
@@ -104,18 +104,17 @@ def main():
     # Passing a path on the command line is treated as granting implicit permission to the container.
     cwd = os.getcwd()
     volumes = []
-    for volume in unique_prefixes(filter_paths(args) + [cwd]):  # N.B. The current working directory is an implicit mount.
+    for volume in unique_prefixes(filter_paths(args) + [cwd] + [ROOT]):  # N.B. The current working directory is an implicit mount.
         volumes.extend(["--volume", f"{volume}:{volume}"])
-    
-    # Construct the command.    
+
+    # Construct the command.
     command = (["docker", "run",
                 "--user", f"{os.getuid()}:{os.getgid()}",
-                "--workdir", cwd,
-                "--volume", f"{ROOT}:/usr/local/src/incontext"] +
+                "--workdir", cwd] +
                volumes +
-               [image_tag, "python3", "-u", "/usr/local/src/incontext/incontext.py"] +
+               [image_tag, "python3", "-u", os.path.join(ROOT, "incontext.py")] +
                args)
-               
+
     # Run incontext in docker.
     logging.debug("Running command %s.", command)
     result = subprocess.run(command)

--- a/incontext.py
+++ b/incontext.py
@@ -23,7 +23,6 @@
 import argparse
 import collections
 import glob
-import importlib
 import logging
 import os
 import sys
@@ -185,14 +184,7 @@ class InContext(object):
         """
 
         # Load the plugins.
-        sys.path.append(self.plugins_directory)
-        plugins = {}
-        for plugin in utils.find_files(self.plugins_directory, [".py"]):
-            plugin = os.path.join(*plugin)
-            (module, _) = os.path.splitext(os.path.relpath(plugin, self.plugins_directory))
-            module = module.replace("/", ".")
-            logging.debug("Importing '%s'...", module)
-            plugins[module] = importlib.import_module(module)
+        plugins = utils.load_plugins(self.plugins_directory)
 
         # Create the argument parser.
         self.parser = argparse.ArgumentParser(prog="incontext", description="Generate website.")

--- a/incontext.py
+++ b/incontext.py
@@ -178,6 +178,7 @@ class InContext(object):
         self.configuration_providers = {}
         self.configuration = Configuration()
         self._plugins = _PLUGINS
+        self._loaded_plugin_directories = {}
 
         # Create the argument parser.
         self.parser = argparse.ArgumentParser(prog="incontext", description="Generate website.")
@@ -193,6 +194,10 @@ class InContext(object):
         """
         Load and initialize the plugins in a given directory, adding them to the incontext instance.
         """
+        directory = os.path.abspath(directory)
+        if directory in self._loaded_plugin_directories:
+            return
+        self._loaded_plugin_directories[directory] = True
         plugins = utils.load_plugins(directory)
         for plugin_name, plugin_instance in plugins.items():
 
@@ -334,7 +339,6 @@ class InContext(object):
         # Once we've taken a first pass at processing the command line arguments, check to see if there's a site-local
         # plugins directory that needs to be loaded.
         plugins_directory = os.path.join(os.path.abspath(options.site), "plugins")
-        logging.info(plugins_directory)
         if os.path.exists(plugins_directory):
             logging.info("Loading site plugins...")
             self.load_plugins(plugins_directory)

--- a/incontext.py
+++ b/incontext.py
@@ -22,6 +22,7 @@
 
 import argparse
 import collections
+import copy
 import glob
 import logging
 import os
@@ -176,7 +177,7 @@ class InContext(object):
         self.arguments = []
         self.configuration_providers = {}
         self.configuration = Configuration()
-        self._plugins = _PLUGINS
+        self._plugins = copy.deepcopy(_PLUGINS)
         self._loaded_plugin_directories = {}
 
         # Load and initialize the plugins.

--- a/tests/common.py
+++ b/tests/common.py
@@ -47,6 +47,9 @@ class Site(object):
         with utils.Chdir(self.path):
             run_incontext(args, plugins_directory=paths.PLUGINS_DIR)
 
+    def incontext(self):
+        return incontext.InContext(plugins_directory=paths.PLUGINS_DIR)
+
     @property
     def store(self):
         if self._store is None:
@@ -58,6 +61,9 @@ class Site(object):
 
     def clean(self):
         self.run(["clean"])
+
+    def makedirs(self, path):
+        utils.makedirs(os.path.join(self.path, path))
 
     def touch(self, path):
         utils.touch(os.path.join(self.temporary_directory.name, path))
@@ -138,8 +144,8 @@ class TemporarySite(Site):
             self.add("site.yaml", self.configuration)
 
         # Create the required directories.
-        utils.makedirs(os.path.join(self.temporary_directory.name, "content"))
-        utils.makedirs(os.path.join(self.temporary_directory.name, "templates"))
+        self.makedirs("content")
+        self.makedirs("templates")
 
         os.chdir(self.temporary_directory.name)
         return self

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -194,15 +194,7 @@ class CommandsTestCase(unittest.TestCase):
                     "url": "https://example.com"
                 },
                 "paths": {},
-                "build_steps": [{
-                    "task": "process_files",
-                    "args": {
-                        "handlers": [{
-                            "when": "(.*/)?.*\.txt",
-                            "then": "copy_file",
-                        }],
-                    }
-                }],
+                "build_steps": [],
             })
             site.makedirs("plugins")
             site.add("plugins/example.py", """
@@ -210,9 +202,8 @@ class CommandsTestCase(unittest.TestCase):
 def initialize_plugin(incontext):
     pass
 
-            """)
+""")
             site.build()
-            # TODO: Check that the incontext instance has the plugin listed?
 
     def test_fail_to_load_invalid_site_plugin(self):
         with common.TemporarySite(self) as site:
@@ -222,15 +213,7 @@ def initialize_plugin(incontext):
                     "url": "https://example.com"
                 },
                 "paths": {},
-                "build_steps": [{
-                    "task": "process_files",
-                    "args": {
-                        "handlers": [{
-                            "when": "(.*/)?.*\.txt",
-                            "then": "copy_file",
-                        }],
-                    }
-                }],
+                "build_steps": [],
             })
             site.makedirs("plugins")
             site.add("plugins/example.py", """
@@ -238,9 +221,41 @@ def initialize_plugin(incontext):
 def initialize_plugin(incontext):
     raise AssertionError("Boom!")
 
-            """)
+""")
             with self.assertRaises(AssertionError):
                 site.build()
+
+    # TODO: Test the decorator-based API for registering commands from site-plugins #117
+    #       https://github.com/inseven/incontext/issues/117
+    def test_site_plugin_with_additional_command(self):
+        with common.TemporarySite(self) as site:
+            site.add("site.yaml", {
+                "config": {
+                    "title": "Example Site",
+                    "url": "https://example.com"
+                },
+                "paths": {},
+                "build_steps": [],
+            })
+            site.makedirs("plugins")
+            site.add("plugins/test_command.py", """
+
+import logging
+
+import incontext
+
+
+def initialize_plugin(incontext):
+    incontext.add_command("new-command", command_new_command)
+
+
+def command_new_command(incontext, parser):
+    def new_command(options):
+        logging.info("success!")
+    return new_command
+
+""")
+            site.run(["new-command"])
 
     @common.with_temporary_directory
     def test_new_site(self):

--- a/utils.py
+++ b/utils.py
@@ -18,13 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import importlib
 import hashlib
+import logging
 import os
 import pathlib
 import re
 import shutil
 import struct
 import subprocess
+import sys
 import tempfile
 
 
@@ -217,3 +220,14 @@ def create_animated_thumbnail(input, output):
 def replace_extension(path, extension):
     root, ext = os.path.splitext(path)
     return root + extension
+
+def load_plugins(path):
+    sys.path.append(path)
+    plugins = {}
+    for plugin in find_files(path, [".py"]):
+        plugin = os.path.join(*plugin)
+        (module, _) = os.path.splitext(os.path.relpath(plugin, path))
+        module = module.replace("/", ".")
+        logging.debug("Importing '%s'...", module)
+        plugins[module] = importlib.import_module(module)
+    return plugins


### PR DESCRIPTION
This change introduces support for user-defined plugins (located in the `plugins` directory in the root of a site). It is intended to allow for per-site addition of convenience commands, image transforms, etc.

The change itself is fairly small:

- introduce a new high-level convenience (in `utils`) for loading plugins
- add tests for this command
- load plugins in the `plugins` directory in a site (if it exists) in addition to the built-in plugins
- add end-to-end tests for the new site-specific plugins