### PR TITLE
Simplify the Docker build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ Pipfile.lock
 __pycache__
 .nova
 .venv
-/plugins/custom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,24 +3,7 @@ FROM ubuntu:$ubuntu_version
 # needed to do again after FROM due to docker limitation
 ARG ubuntu_version
 
-ARG DEBIAN_FRONTEND=noninteractive
-
 ENV INCONTEXT_DIR /usr/local/src/incontext
-
-# Install the package dependencies.
 WORKDIR ${INCONTEXT_DIR}
-COPY . ${INCONTEXT_DIR}/
-RUN apt-get update
-RUN bash -c "cat docker/requirements.txt | xargs apt-get install -y"
-
-RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
-RUN dpkg-reconfigure --frontend noninteractive tzdata
-
-# Install ImageMagick with HEIC support
-WORKDIR ${INCONTEXT_DIR}/docker
-RUN bash install_imagemagick.sh
-
-# Install the Python dependencies.
-WORKDIR ${INCONTEXT_DIR}/docker
-RUN python3 -m pip install pipenv
-RUN pipenv install --verbose --system --skip-lock
+COPY docker ${INCONTEXT_DIR}/
+RUN bash setup.sh

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install the package dependencies.
+cd $INCONTEXT_DIR
+apt-get update
+cat requirements.txt | xargs apt-get install -y
+
+# Timezone support
+ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+dpkg-reconfigure --frontend noninteractive tzdata
+
+# Install ImageMagick with HEIC support
 sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
 apt-get update
 apt-get install -y build-essential autoconf git-core wget
@@ -10,18 +24,28 @@ git clone https://github.com/strukturag/libheif.git
 cd libde265/
 ./autogen.sh
 ./configure
-make –j4
+make
 make install
 cd /usr/src/libheif/
 ./autogen.sh
 ./configure
-make –j4
+make
 make install
 cd /usr/src/
 wget https://www.imagemagick.org/download/ImageMagick.tar.gz
 tar xf ImageMagick.tar.gz
+rm ImageMagick.tar.gz
 cd ImageMagick-7*
 ./configure --with-heic=yes
-make –j4
+make
 make install
 ldconfig
+
+# Install the Python dependencies.
+cd $INCONTEXT_DIR
+python3 -m pip install pipenv
+pipenv install --verbose --system --skip-lock
+
+# Clean up the working directory.
+cd /
+rm -r $INCONTEXT_DIR


### PR DESCRIPTION
This change pulls all the Docker container customisation into the `setup.sh` script, performs some post-installation cleanup, and no longer copies the InContext script into the build (see #16).

It also includes a drive-by fix to remove a now-defunct git ignore.