### PR TITLE
Support interactive plugins

### DIFF
--- a/incontext
+++ b/incontext
@@ -107,12 +107,17 @@ def main():
     for volume in unique_prefixes(filter_paths(args) + [cwd] + [ROOT]):  # N.B. The current working directory is an implicit mount.
         volumes.extend(["--volume", f"{volume}:{volume}"])
 
+    options = []
+    if sys.flags.interactive:
+        options.append("--tty")
+        options.append("--interactive")
+
     # Construct the command.
     command = (["docker", "run",
                 "--tty",
-                "--interactive",
                 "--user", f"{os.getuid()}:{os.getgid()}",
                 "--workdir", cwd] +
+               options +
                volumes +
                [image_tag, "python3", "-u", os.path.join(ROOT, "incontext.py")] +
                args)

--- a/incontext
+++ b/incontext
@@ -108,7 +108,9 @@ def main():
         volumes.extend(["--volume", f"{volume}:{volume}"])
 
     options = []
-    if sys.flags.interactive:
+    # Determine whether we're in interactive mode.
+    # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
+    if hasattr(sys, 'ps1'):
         options.append("--tty")
         options.append("--interactive")
 

--- a/incontext
+++ b/incontext
@@ -109,6 +109,8 @@ def main():
 
     # Construct the command.
     command = (["docker", "run",
+                "--tty",
+                "--interactive",
                 "--user", f"{os.getuid()}:{os.getgid()}",
                 "--workdir", cwd] +
                volumes +


### PR DESCRIPTION
Support running interactive code in InContext plugins by adding the `--tty` and `--interactive` flags to the `run` command in the wrapper script.

Fix for 'InContext plugins cannot run interactively #127' (https://github.com/inseven/incontext/issues/127).