### PR TITLE
fix: Return None for absent document properties

### DIFF
--- a/service/website.py
+++ b/service/website.py
@@ -208,9 +208,7 @@ class DocumentWrapper(object):
         try:
             return self._document[name]
         except KeyError:
-            if name == "date":
-                return None
-            raise AttributeError
+            return None
 
     @property
     def hash(self):


### PR DESCRIPTION
It looks like there might have been a change in Jinja that means attribute errors are no longer swallowed, making it unsafe to access missing properties. This change addresses that by ensuring missing properties return None.