### PR TITLE
refactor: Common library to automatically watch for changes and rebuild

### DIFF
--- a/plugins/commands/build.py
+++ b/plugins/commands/build.py
@@ -27,9 +27,14 @@ import os
 import re
 import shutil
 import subprocess
+import threading
+import time
 
 import fnmatch
 import yaml
+
+import watchdog.events
+import watchdog.observers
 
 import converters
 import handlers.gallery as gallery
@@ -329,3 +334,97 @@ class Phase(object):
                     self.tracker.add(os.path.join(root, dirname, basename), debug_task(task, relpath))
                     break
         self.tracker.commit(cleanup(self.root, self.document_store))
+
+
+class Builder(threading.Thread):
+
+    def __init__(self, incontext, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.incontext = incontext
+        self.scheduled = False
+        self.lock = threading.Lock()
+        self.stopped = False
+
+    def schedule(self):
+        logging.info("Scheduling build...")
+        with self.lock:
+            self.scheduled = True
+
+    def stop(self):
+        logging.info("Stopping builder...")
+        with self.lock:
+            self.stopped = True
+
+    def run(self):
+        while True:
+            time.sleep(1)
+            scheduled = False
+            with self.lock:
+                if self.stopped:
+                    return
+                scheduled = self.scheduled
+                self.scheduled = False
+            if scheduled:
+                try:
+                    self.incontext.commands["build"].run()
+                    logging.info("Done.")
+                except Exception as e:
+                    logging.error("Failed: %s", e)
+
+
+class CallbackEventHandler(watchdog.events.FileSystemEventHandler):
+    """Logs all the events captured."""
+
+    def __init__(self, callback):
+        self._callback = callback
+
+    def on_moved(self, event):
+        super(CallbackEventHandler, self).on_moved(event)
+        self._callback()
+
+    def on_created(self, event):
+        self._callback()
+
+    def on_deleted(self, event):
+        self._callback()
+
+    def on_modified(self, event):
+        self._callback()
+
+
+class WatchingBuilder(object):
+
+    def __init__(self, incontext):
+        self.incontext = incontext
+
+    def start(self):
+        self.builder = Builder(self.incontext)
+        self.builder.start()
+
+        def watch_directory(paths, callback):
+            observer = watchdog.observers.Observer()
+            for path in paths:
+                observer.schedule(CallbackEventHandler(callback=callback), path, recursive=True)
+            observer.start()
+            return observer
+
+        logging.info("Watching directory...")
+        self.observer = watch_directory([self.incontext.configuration.site.paths.content,
+                                         self.incontext.configuration.site.paths.templates],
+                                         self.builder.schedule)
+
+        logging.info("Performing initial build...")
+        self.builder.schedule()
+
+    def stop(self):
+        self.builder.stop()
+        self.observer.stop()
+        self.observer.join()
+        self.builder.join()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()

--- a/plugins/commands/watch.py
+++ b/plugins/commands/watch.py
@@ -19,13 +19,13 @@
 # SOFTWARE.
 
 import atexit
+import contextlib
+import http.server
 import logging
 import os
 import signal
 import subprocess
 import sys
-import threading
-import time
 import urllib
 import webbrowser
 
@@ -34,94 +34,12 @@ import watchdog.observers
 
 import incontext
 import paths
+import utils
 
-
-class CallbackEventHandler(watchdog.events.FileSystemEventHandler):
-    """Logs all the events captured."""
-
-    def __init__(self, callback):
-        self._callback = callback
-
-    def on_moved(self, event):
-        super(CallbackEventHandler, self).on_moved(event)
-        self._callback()
-
-    def on_created(self, event):
-        self._callback()
-
-    def on_deleted(self, event):
-        self._callback()
-
-    def on_modified(self, event):
-        self._callback()
-
-
-def watch_directory(paths, callback):
-    observer = watchdog.observers.Observer()
-    for path in paths:
-        observer.schedule(CallbackEventHandler(callback=callback), path, recursive=True)
-    observer.start()
-    return observer
-
-
-class Builder(threading.Thread):
-
-    def __init__(self, incontext, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.incontext = incontext
-        self.scheduled = False
-        self.lock = threading.Lock()
-        self.stopped = False
-
-    def schedule(self):
-        logging.info("Scheduling build...")
-        with self.lock:
-            self.scheduled = True
-
-    def stop(self):
-        logging.info("Stopping builder...")
-        with self.lock:
-            self.stopped = True
-
-    def run(self):
-        while True:
-            time.sleep(1)
-            scheduled = False
-            with self.lock:
-                if self.stopped:
-                    return
-                scheduled = self.scheduled
-                self.scheduled = False
-            if scheduled:
-                try:
-                    self.incontext.commands["build"].run()
-                    logging.info("Done.")
-                except Exception as e:
-                    logging.error("Failed: %s", e)
-
-
-def docker(command):
-    prefix = []
-    if sys.platform == "linux":
-        prefix = ["sudo"]
-    return subprocess.run(prefix + ["docker"] + command)
+import commands.build
 
 
 @incontext.command("watch", help="watch for changes and automatically build the website")
 def command_watch(incontext, options):
-    builder = Builder(incontext)
-    builder.start()
-    logging.info("Watching directory...")
-    observer = watch_directory([incontext.configuration.site.paths.content,
-                                incontext.configuration.site.paths.templates],
-                               builder.schedule)
-    logging.info("Performing initial build...")
-    builder.schedule()
-    try:
-        while True:
-            time.sleep(0.2)
-    except KeyboardInterrupt:
-        builder.stop()
-        observer.stop()
-    observer.join()
-    builder.join()
+    with commands.build.WatchingBuilder(incontext):
+        utils.wait_for_keyboard_interrupt()

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import time
 
 
 class Chdir(object):
@@ -252,3 +253,11 @@ def load_plugins(path):
             importlib.import_module(module)
         plugins[module] = sys.modules[module]
     return plugins
+
+
+def wait_for_keyboard_interrupt():
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        return


### PR DESCRIPTION
The goal is to reuse this in both an upcoming `serve` command, and add the functionality to the `build` command.