### PR TITLE
ci: Prune Docker builds to ensure the cache isn't full

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ jobs:
         submodules: recursive
         lfs: true
 
+    - name: Prune Docker images
+      run: |
+        docker system prune -f
+
     - name: Run tests
       run: |
         python3 -u incontext --no-cache --verbose tests


### PR DESCRIPTION
It's unfortunate that we have to do this, but it seems to be the only way to ensure the build machines don't get completely swamped with images. Perhaps a more elegant approach would be to have a dedicated maintenence task that kept the build machines clean, but it amounts to the same thing and this is at least clear and explicit.