### PR TITLE
feat: Log the full URL for the local server

### DIFF
--- a/plugins/commands/serve.py
+++ b/plugins/commands/serve.py
@@ -42,7 +42,7 @@ def command_serve(incontext, options):
     with builder_context, utils.Chdir(incontext.configuration.site.destination.files_directory):
         httpd = http.server.HTTPServer(('', options.port),
                                        http.server.SimpleHTTPRequestHandler)
-        logging.info("Listening on %s...", options.port)
+        logging.info("Serving site on http://localhost:%s...", options.port)
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:


### PR DESCRIPTION
This change logs the full URL (http://localhost:...) instead of just the port number when starting up the server to make it easier to quickly click on the URL to launch a browser.