### PR TITLE
fix: Support Unicode line separators in Front Matter and Markdown

### DIFF
--- a/converters.py
+++ b/converters.py
@@ -34,11 +34,21 @@ sys.path.append(paths.SERVICE_DIR)
 import store
 
 
-def read_frontmatter(path):
-    fm = frontmatter.load(path)
+def parse_frontmatter(string):
+    # Front Matter and Markdown don't understand Unicode line separators so we replace them with a simple new line
+    # to ensure we're as permissive as possible. This fix was introduced to address issues with Markdown in captions
+    # of photos exported by Photos for macOS which appears to offer no way to insert paragraph separators or new
+    # lines.
+    content = string.replace("\u2028", "\n")
+    fm = frontmatter.loads(content)
     data = fm.metadata
     data["content"] = fm.content
     return data
+
+
+def read_frontmatter(path):
+    with open(path) as fh:
+        return parse_frontmatter(fh.read())
 
 
 def clean_name(path):

--- a/plugins/handlers/gallery.py
+++ b/plugins/handlers/gallery.py
@@ -344,13 +344,9 @@ def metadata_from_exif(path):
     `METADATA_SCHEMA`.
     """
     data = METADATA_SCHEMA(exif(path))
-
     if data["content"] is not None:
-        fm = frontmatter.loads(data["content"])
-        frontmatter_data = fm.metadata
-        frontmatter_data["content"] = fm.content
+        frontmatter_data = converters.parse_frontmatter(data["content"])
         data = utils.merge_dictionaries(data, frontmatter_data)
-
     return data
 
 

--- a/tests/test_exif.py
+++ b/tests/test_exif.py
@@ -34,6 +34,7 @@ import gallery
 
 IMG_4056_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "exif/IMG_4056.jpeg")
 IMG_4056_WITH_SIDECAR_JPEG = os.path.join(paths.TEST_DATA_DIRECTORY, "exif/IMG_4056_with_sidecar.jpeg")
+IMAGE_WITH_FRONTMATTER_AND_LINE_SEPARATORS = os.path.join(paths.TEST_DATA_DIRECTORY, "exif/2022-07-02-14-20-38-coaltown.jpeg")
 
 
 class ExifTestCase(unittest.TestCase):
@@ -49,3 +50,7 @@ class ExifTestCase(unittest.TestCase):
     def test_sidecar_overrides_title(self):
         metadata = gallery.metadata_from_exif(IMG_4056_WITH_SIDECAR_JPEG)
         self.assertEqual(metadata["title"], "Sunrise")
+
+    def test_caption_with_frontmatter_and_line_separators(self):
+        metadata = gallery.metadata_from_exif(IMAGE_WITH_FRONTMATTER_AND_LINE_SEPARATORS)
+        self.assertEqual(metadata["title"], "Coaltown")


### PR DESCRIPTION
The Front Matter and Markdown libraries we’re using don’t seem to know what to do with Unicode line separators; they just ignore them. This means that content generated by editors which insert these instead of regular new lines (I’m looking at you, Photos for macOS) doesn’t render correctly. This change pre-processes the input to replace Unicode line separators (`\u2028`) with a regular new line (`\n`).