### PR TITLE
fix: Use the Front Matter title as the basename when publishing posts

### DIFF
--- a/incontext.py
+++ b/incontext.py
@@ -172,6 +172,7 @@ class InContext(object):
         self.configuration = Configuration()
         self._plugins = copy.deepcopy(_PLUGINS)
         self._loaded_plugin_directories = {}
+        self.extensions = {}
 
         # Load and initialize the plugins.
         self.load_plugins(os.path.abspath(plugins_directory))
@@ -303,6 +304,25 @@ class InContext(object):
         @rtype: callable
         """
         return self.handlers[name]
+
+    def add_extension(self, name, function):
+        """
+        Register a top-level extension to make it available to other plugins.
+
+        For example, this can be used to register a top-level function for importing Markdown documents that can be
+        shared across plugins.
+
+        @param name: The extension name.
+        @type name: str
+        @param function: The function to be called.
+        @type function: callable
+        """
+        if name in self.extensions:
+            raise AssertionError("Extension '%s' is already defined." % name)
+        self.extensions[name] = function
+
+    def __getattr__(self, name):
+        return self.extensions[name]
 
     def parser(self, add_subparsers=True):
         """

--- a/plugins/commands/build.py
+++ b/plugins/commands/build.py
@@ -54,6 +54,13 @@ def initialize_plugin(incontext):
     incontext.add_handler("import_markdown", import_markdown)
     incontext.add_task("process_files", process_files)
 
+    # Register utility functions.
+    def load_frontmatter_document(path, *args, **kwargs):
+        root = incontext.configuration.site.root
+        relative_path = os.path.relpath(os.path.abspath(path), root)
+        return converters.frontmatter_document(root, relative_path, *args, **kwargs)
+    incontext.add_extension("load_frontmatter_document", load_frontmatter_document)
+
 
 class SiteConfiguration(object):
 

--- a/plugins/manage.py
+++ b/plugins/manage.py
@@ -189,10 +189,17 @@ def command_publish(incontext, parser):
     parser.add_argument("path", help="path to post to publish")
 
     def publish(options):
-        basename = os.path.basename(options.path)
+
+        # Read the title and determine a suitable basename.
+        document = incontext.load_frontmatter_document(os.path.join(options.path, "index.markdown"))
+        basename = utils.safe_basename(document.title)
         date = datetime.datetime.now().strftime("%Y-%m-%d")
-        utils.makedirs(incontext.configuration.site.paths.posts)
         destination = os.path.join(incontext.configuration.site.paths.posts, "%s-%s" % (date, basename))
+
+        # Ensure the destination directory exists.
+        utils.makedirs(incontext.configuration.site.paths.posts)
+
+        # Move the file to the new location.
         logging.info("Publishing to '%s'..." % (os.path.relpath(destination, incontext.configuration.site.root), ))
         shutil.move(os.path.abspath(options.path), destination)
 


### PR DESCRIPTION
This change also introduces an experimental approach to extending the core `InContext` allowing plugins to export convenience, context aware, functions to other plugins.