### PR TITLE
test: TIFF transform now works in the latest Alpine images

### DIFF
--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -161,9 +161,6 @@ class GalleryTestCase(unittest.TestCase):
         output_size = gallery.get_size(expected_basename, 1)
         self.assertEqual(output_size["width"], size[0])
 
-    # TODO: ImageMagick crashes during TIFF conversion in the new Alpine-based Docker container #144
-    #       https://github.com/inseven/incontext/issues/144
-    @unittest.expectedFailure
     @common.with_temporary_directory
     def test_resize_tiff(self):
 
@@ -538,9 +535,6 @@ class GalleryTestCase(unittest.TestCase):
             with self.assertRaises(KeyError):
                 site.build()
 
-    # TODO: ImageMagick crashes during TIFF conversion in the new Alpine-based Docker container #144
-    #       https://github.com/inseven/incontext/issues/144
-    @unittest.expectedFailure
     def test_image_title_from_exif(self):
         with common.TemporarySite(self) as site:
             site.add("templates/photo.html", "{{ page.title }}")

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -412,9 +412,6 @@ class GalleryTestCase(unittest.TestCase):
             site.assertMIMEType("build/files/image/thumbnail.jpeg", "image/jpeg")
             site.assertImageSize("build/files/image/thumbnail.jpeg", (480, 360))
 
-    # TODO: ImageMagick crashes during TIFF conversion in the new Alpine-based Docker container #144
-    #       https://github.com/inseven/incontext/issues/144
-    @unittest.expectedFailure
     def test_transform_image_tiff_default_configuration(self):
         with common.TemporarySite(self) as site:
             site.add("templates/photo.html", "{{ page.title }}\n")


### PR DESCRIPTION
This change removes the `expectedFailure` decorator from the relevant tests.