### PR TITLE
fix: Ensure SVGs display correctly in Safari

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "Dependencies/diligence"]
 	path = Dependencies/diligence
 	url = git@github.com:inseven/diligence.git
+[submodule "Dependencies/hummingbird"]
+	path = Dependencies/hummingbird
+	url = git@github.com:jbmorley/hummingbird.git

--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,13 @@ let package = Package(
             ]),
     ],
     dependencies: [
+        .package(path: "Dependencies/hummingbird"),
         .package(path: "Dependencies/Tilt"),
         .package(url: "https://github.com/Frizlab/FSEventsWrapper.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", from: "0.2.0"),
         .package(url: "https://github.com/behrang/YamlSwift.git", from: "3.4.4"),  // Good for unknown?
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "1.7.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),  // Good for known structures
         .package(url: "https://github.com/jwells89/Titlecaser.git", from: "1.0.0"),
         .package(url: "https://github.com/objecthub/swift-markdownkit.git", from: "1.1.7"),


### PR DESCRIPTION
This change switches to using a custom fork of Hummingbird. It's technically unnecessary since Hummingbird has accepted the required SVG fix, but it will help shield against unnecessary changes in the project and ease other fixes in the future.