### PR TITLE
fix: Clean up the import configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ These changes impact the rendering of jbmorley.co.uk and block switching to InCo
 1. **Deleted documents aren't removed from the store**
 2. **Check adaptive images work**
 3. **Don't automatically replace non-Markdown image tags**
-6. Pass-through site metadata so that things like tags can be rendered correctly
 7. Check that gifs are transformed correctly
 8. Markdown issues (Footnotes, Strikethrough, mdash)
 9. Scale videos

--- a/Sources/InContextCore/Builder.swift
+++ b/Sources/InContextCore/Builder.swift
@@ -58,7 +58,7 @@ public class Builder {
             "site": [
                 "title": site.title,
                 "url": site.url.absoluteString,
-                "metadata": site.structuredSettings.metadata,
+                "metadata": site.metadata,
                 "date_format": "MMMM d, yyyy",
                 "date_format_short": "MMMM d",
                 "documents": Function { () throws -> [DocumentContext] in

--- a/Sources/InContextCore/Importers/CopyImporter.swift
+++ b/Sources/InContextCore/Importers/CopyImporter.swift
@@ -30,7 +30,7 @@ class CopyImporter: Importer {
     let version = 1
 
     func settings(for configuration: [String : Any]) throws -> EmptySettings {
-        guard configuration["args"] == nil else {
+        guard configuration.isEmpty else {
             throw InContextError.unexpecteArgs
         }
         return EmptySettings()

--- a/Sources/InContextCore/Importers/EmptySettings.swift
+++ b/Sources/InContextCore/Importers/EmptySettings.swift
@@ -22,45 +22,10 @@
 
 import Foundation
 
-struct ImporterResult {
+// To be used when no settings are required; returns a struct even if not specified.
+struct EmptySettings: ImporterSettings {
 
-    let document: Document?
-    let assets: [Asset]
-
-    init(document: Document? = nil, assets: [Asset] = []) {
-        self.document = document
-        self.assets = assets
-    }
+    func combine(into fingerprint: inout Fingerprint) throws {}
 
 }
 
-protocol ImporterSettings: Hashable, Fingerprintable {
-
-}
-
-protocol Importer {
-
-    associatedtype Settings: ImporterSettings
-
-    var identifier: String { get }
-    var version: Int { get }
-
-    func settings(for configuration: [String: Any]) throws -> Settings
-    func process(file: File,
-                 settings: Settings,
-                 outputURL: URL) async throws -> ImporterResult
-
-}
-
-extension Importer {
-
-    func handler(when: String, then: String, args: [String: Any]) throws -> AnyHandler {
-        // Double-check that the type is correct.
-        guard then == self.identifier else {
-            throw InContextError.internalInconsistency("Unexpected type for handler settings.")
-        }
-        let handler = try Handler(when: when, importer: self, settings: try self.settings(for: args))
-        return AnyHandler(handler)
-    }
-
-}

--- a/Sources/InContextCore/Importers/IgnoreImporter.swift
+++ b/Sources/InContextCore/Importers/IgnoreImporter.swift
@@ -30,7 +30,7 @@ class IgnoreImporter: Importer {
     let version = 1
 
     func settings(for configuration: [String : Any]) throws -> EmptySettings {
-        guard configuration["args"] == nil else {
+        guard configuration.isEmpty else {
             throw InContextError.unexpecteArgs
         }
         return EmptySettings()

--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -303,11 +303,10 @@ class ImageImporter: Importer {
     let version = 10
 
     func settings(for configuration: [String : Any]) throws -> Settings {
-        let args: [String: Any] = try configuration.requiredValue(for: "args")
-        return Settings(defaultCategory: try args.requiredValue(for: "category"),
-                        titleFromFilename: try args.requiredValue(for: "title_from_filename"),
-                        defaultTemplate: try args.requiredRawRepresentable(for: "default_template"),
-                        inlineTemplate: try args.requiredRawRepresentable(for: "inline_template"))
+        return Settings(defaultCategory: try configuration.requiredValue(for: "category"),
+                        titleFromFilename: try configuration.requiredValue(for: "titleFromFilename"),
+                        defaultTemplate: try configuration.requiredRawRepresentable(for: "defaultTemplate"),
+                        inlineTemplate: try configuration.requiredRawRepresentable(for: "inlineTemplate"))
     }
 
     func process(file: File,

--- a/Sources/InContextCore/Importers/MarkdownImporter.swift
+++ b/Sources/InContextCore/Importers/MarkdownImporter.swift
@@ -40,9 +40,8 @@ class MarkdownImporter: Importer {
     let version = 11
 
     func settings(for configuration: [String : Any]) throws -> Settings {
-        let args: [String: Any] = try configuration.requiredValue(for: "args")
-        return Settings(defaultCategory: try args.requiredValue(for: "default_category"),
-                        defaultTemplate: try args.requiredRawRepresentable(for: "default_template"))
+        return Settings(defaultCategory: try configuration.requiredValue(for: "defaultCategory"),
+                        defaultTemplate: try configuration.requiredRawRepresentable(for: "defaultTemplate"))
     }
 
     func process(file: File,

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -43,11 +43,10 @@ class VideoImporter: Importer {
     let version = 8
 
     func settings(for configuration: [String : Any]) throws -> Settings {
-        let args: [String: Any] = try configuration.requiredValue(for: "args")
-        return Settings(defaultCategory: try args.requiredValue(for: "category"),
-                        titleFromFilename: try args.requiredValue(for: "title_from_filename"),
-                        defaultTemplate: try args.requiredRawRepresentable(for: "default_template"),
-                        inlineTemplate: try args.requiredRawRepresentable(for: "inline_template"))
+        return Settings(defaultCategory: try configuration.requiredValue(for: "category"),
+                        titleFromFilename: try configuration.requiredValue(for: "titleFromFilename"),
+                        defaultTemplate: try configuration.requiredRawRepresentable(for: "defaultTemplate"),
+                        inlineTemplate: try configuration.requiredRawRepresentable(for: "inlineTemplate"))
     }
 
     func process(file: File,

--- a/Sources/InContextCore/Server.swift
+++ b/Sources/InContextCore/Server.swift
@@ -43,7 +43,7 @@ public class Server {
                 serializeRender: Bool = false) {
         self.site = site
         self.tracker = tracker
-        self.port = site.structuredSettings.port
+        self.port = site.port
         self.serializeImport = serializeImport
         self.serializeRender = serializeRender
     }

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -30,7 +30,7 @@ class ImageImporterTests: ContentTestCase {
     func testExtractTitle() async throws {
 
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-version: 1
+version: 2
 title: Example
 url: http://example.com
 build_steps:

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -33,17 +33,14 @@ class ImageImporterTests: ContentTestCase {
 version: 2
 title: Example
 url: http://example.com
-build_steps:
-  - task: process_files
+steps:
+  - when: '(.*/)?.*\\.jpeg'
+    then: image
     args:
-      handlers:
-        - when: '(.*/)?.*\\.jpeg'
-          then: image
-          args:
-              category: general
-              defaultTemplate: photo.html
-              inlineTemplate: image.html
-              titleFromFilename: false
+        category: general
+        defaultTemplate: photo.html
+        inlineTemplate: image.html
+        titleFromFilename: false
 """)
 
 

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -41,9 +41,9 @@ build_steps:
           then: image
           args:
               category: general
-              default_template: photo.html
-              inline_template: image.html
-              title_from_filename: false
+              defaultTemplate: photo.html
+              inlineTemplate: image.html
+              titleFromFilename: false
 """)
 
 

--- a/Tests/InContextTests/Tests/MarkdownImporterTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownImporterTests.swift
@@ -39,8 +39,8 @@ build_steps:
         - when: '(.*/)?.*\\.markdown'
           then: markdown
           args:
-              default_category: general
-              default_template: posts.html
+              defaultCategory: general
+              defaultTemplate: posts.html
 """)
         let file = try defaultSourceDirectory.add("cheese/index.markdown", location: .content, contents: """
 ---
@@ -70,8 +70,8 @@ build_steps:
         - when: '(.*/)?.*\\.markdown'
           then: markdown
           args:
-              default_category: general
-              default_template: posts.html
+              defaultCategory: general
+              defaultTemplate: posts.html
 """)
         let file = try defaultSourceDirectory.add("cheese/index.markdown", location: .content, contents: "Contents!")
         let importer = MarkdownImporter()

--- a/Tests/InContextTests/Tests/MarkdownImporterTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownImporterTests.swift
@@ -32,15 +32,12 @@ class MarkdownImporterTests: ContentTestCase {
 version: 2
 title: Example
 url: http://example.com
-build_steps:
-  - task: process_files
+steps:
+  - when: '(.*/)?.*\\.markdown'
+    then: markdown
     args:
-      handlers:
-        - when: '(.*/)?.*\\.markdown'
-          then: markdown
-          args:
-              defaultCategory: general
-              defaultTemplate: posts.html
+        defaultCategory: general
+        defaultTemplate: posts.html
 """)
         let file = try defaultSourceDirectory.add("cheese/index.markdown", location: .content, contents: """
 ---
@@ -63,15 +60,12 @@ These are the contents of the file.
 version: 2
 title: Example
 url: http://example.com
-build_steps:
-  - task: process_files
+steps:
+  - when: '(.*/)?.*\\.markdown'
+    then: markdown
     args:
-      handlers:
-        - when: '(.*/)?.*\\.markdown'
-          then: markdown
-          args:
-              defaultCategory: general
-              defaultTemplate: posts.html
+        defaultCategory: general
+        defaultTemplate: posts.html
 """)
         let file = try defaultSourceDirectory.add("cheese/index.markdown", location: .content, contents: "Contents!")
         let importer = MarkdownImporter()

--- a/Tests/InContextTests/Tests/MarkdownImporterTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownImporterTests.swift
@@ -29,7 +29,7 @@ class MarkdownImporterTests: ContentTestCase {
 
     func testMarkdownTitleOverride() async throws {
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-version: 1
+version: 2
 title: Example
 url: http://example.com
 build_steps:
@@ -60,7 +60,7 @@ These are the contents of the file.
 
     func testMarkdownTitleFromFile() async throws {
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-version: 1
+version: 2
 title: Example
 url: http://example.com
 build_steps:

--- a/docs/content/css/main.css
+++ b/docs/content/css/main.css
@@ -57,3 +57,8 @@ nav li:last-child::after {
 footer {
     text-align: center;
 }
+
+code {
+    background-color: #f0f0f0;
+    padding: 0.2em;
+}

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -2,43 +2,75 @@
 title: Configuration
 ---
 
-Looks something like this:
+The site configuration is stored as [YAML](https://yaml.org) in 'site.yaml' in the root of the site.
+
+# Example
+
+A typical configuration (the one for this site) looks something like this:
 
 ```yaml
-version: 1
+version: 2
 
 title: InContext
 url: "https://incontext.app"
 
 port: 8003
 
-build_steps:
+steps:
 
-  - task: "process_files"
+  # Ignore temporary and hidden files.
+  - when: '(.*/)?(\.DS_Store|.*~|\..*)'
+    then: ignore
+
+  # Import markdown files.
+  - when: '.*\.(markdown|md)'
+    then: markdown
     args:
-      handlers:
+        defaultCategory: recipes
+        defaultTemplate: page.html
 
-        # Ignore temporary and hidden files.
-        - when: '(.*/)?(\.DS_Store|.*~|\..*)'
-          then: ignore
+  # Import image files.
+  - when: '(.*/)?.*\.(jpg|jpeg|png|gif|tiff|heic)'
+    then: image
+    args:
+        category: images
+        titleFromFilename: False
+        defaultTemplate: photo.html
+        inlineTemplate: image.html
 
-        # Import markdown files.
-        - when: '.*\.(markdown|md)'
-          then: markdown
-          args:
-              default_category: recipes
-              default_template: page.html
+  # Copy everything else.
+  - when: '.*'
+    then: copy
 
-        # Import image files.
-        - when: '(.*/)?.*\.(jpg|jpeg|png|gif|tiff|heic)'
-          then: image
-          args:
-              category: images
-              title_from_filename: False
-              default_template: photo.html
-              inline_template: image.html
-
-        # Copy everything else.
-        - when: '.*'
-          then: copy
 ```
+
+# Properties
+
+## `version` (String)
+
+Configuration version.
+
+This is expected to change quickly as the latest iteration of InContext stabilises. During this initial development
+phase, only the latest version (currently version 2) will be supported, but there are plans to offer backwards
+compatibility where possible following a period of stabilisation.
+
+## `title` (String)
+
+Site title.
+
+Available to templates as `site.title`.
+
+## `url` (URL)
+
+Public URL for the site.
+
+Where the site will be hosted. It's available to templates as `site.url` and will be used by the Helper app and
+command-line app to open the site in the system browser.
+
+## `port` (Int, Default = 8000)
+
+Port number used for the local development server.
+
+Both the Helper app and command-line app use the port number when creating a local development server. When running
+multiple development servers for different sites (the Helper app will do this by default), you should ensure you select
+different ports for each sites.

--- a/docs/site.yaml
+++ b/docs/site.yaml
@@ -1,36 +1,32 @@
-version: 1
+version: 2
 
 title: InContext
 url: "https://incontext.app"
 
 port: 8003
 
-build_steps:
+steps:
 
-  - task: "process_files"
+  # Ignore temporary and hidden files.
+  - when: '(.*/)?(\.DS_Store|.*~|\..*)'
+    then: ignore
+
+  # Import markdown files.
+  - when: '.*\.(markdown|md)'
+    then: markdown
     args:
-      handlers:
+        defaultCategory: recipes
+        defaultTemplate: page.html
 
-        # Ignore temporary and hidden files.
-        - when: '(.*/)?(\.DS_Store|.*~|\..*)'
-          then: ignore
+  # Import image files.
+  - when: '(.*/)?.*\.(jpg|jpeg|png|gif|tiff|heic)'
+    then: image
+    args:
+        category: images
+        titleFromFilename: False
+        defaultTemplate: photo.html
+        inlineTemplate: image.html
 
-        # Import markdown files.
-        - when: '.*\.(markdown|md)'
-          then: markdown
-          args:
-              default_category: recipes
-              default_template: page.html
-
-        # Import image files.
-        - when: '(.*/)?.*\.(jpg|jpeg|png|gif|tiff|heic)'
-          then: image
-          args:
-              category: images
-              title_from_filename: False
-              default_template: photo.html
-              inline_template: image.html
-
-        # Copy everything else.
-        - when: '.*'
-          then: copy
+  # Copy everything else.
+  - when: '.*'
+    then: copy


### PR DESCRIPTION
This change adopts the type-safe configuration for most of 'site.yaml' and cleans up the definition of the importer steps. It represents a breaking change to the configuration and, as such, bumps the configuration version to 2. This is preparatory work for extracting path generation and defaults to a top-level structure that can be shared between importers to simplify settings.