### PR TITLE
fix: Reduce priority of background builds

### DIFF
--- a/InContext/Helper/Model/SiteModel.swift
+++ b/InContext/Helper/Model/SiteModel.swift
@@ -70,7 +70,7 @@ class SiteModel: ObservableObject, Identifiable {
 
     func start() {
         dispatchPrecondition(condition: .onQueue(.main))
-        self.task = Task {
+        self.task = Task(priority: .background) {
             do {
                 try await server.start(watch: true)
             } catch {


### PR DESCRIPTION
Using the default task priority for background builds leaves the UI unresponsive during builds. Reducing this to `.background` will slow builds but leaves the app responsive.