### PR TITLE
fix: Use millisecond granularity when tracking file modification times

### DIFF
--- a/Sources/InContextCore/Builder.swift
+++ b/Sources/InContextCore/Builder.swift
@@ -240,9 +240,8 @@ public class Builder {
                     if let status = try await self.store.status(for: fileURL.relativePath,
                                                                 contentURL: self.site.contentURL) {
 
-                        let fileModified = !Calendar.current.isDate(status.contentModificationDate,
-                                                                    equalTo: contentModificationDate,
-                                                                    toGranularity: .nanosecond)
+                        let fileModified = (status.contentModificationDate.millisecondsSinceReferenceDate !=
+                                            contentModificationDate.millisecondsSinceReferenceDate)
                         let differentImporterVersion = status.fingerprint != handlerFingerprint
 
                         if !fileModified && !differentImporterVersion {

--- a/Sources/InContextCore/Extensions/Date.swift
+++ b/Sources/InContextCore/Extensions/Date.swift
@@ -24,6 +24,15 @@ import Foundation
 
 extension Date: EvaluationContext {
 
+    var millisecondsSinceReferenceDate: Int {
+        return Int(timeIntervalSinceReferenceDate * 1000)
+    }
+
+    init(millisecondsSinceReferenceDate: Int) {
+        let timeInterval: TimeInterval = Double(millisecondsSinceReferenceDate) / 1000.0
+        self.init(timeIntervalSinceReferenceDate: timeInterval)
+    }
+
     func lookup(_ name: String) throws -> Any? {
         switch name {
         case "format": return Function { (format: String) -> String in

--- a/Sources/InContextCore/Store/Store.swift
+++ b/Sources/InContextCore/Store/Store.swift
@@ -35,7 +35,7 @@ class Store {
 
         // common
         static let url = Expression<String>("url")
-        static let contentModificationDate = Expression<Date>("content_modification_date")
+        static let contentModificationDate = Expression<Int>("content_modification_date")
         static let relativeSourcePath = Expression<String>("relative_source_path")
         static let fingerprint = Expression<String>("fingerprint")
 
@@ -177,7 +177,7 @@ class Store {
                                                            Schema.title <- document.title,
                                                            Schema.metadata <- metadata,
                                                            Schema.contents <- document.contents,
-                                                           Schema.contentModificationDate <- document.contentModificationDate,
+                                                           Schema.contentModificationDate <- document.contentModificationDate.millisecondsSinceReferenceDate,
                                                            Schema.template <- document.template,
                                                            Schema.inlineTemplate <- document.inlineTemplate,
                                                            Schema.relativeSourcePath <- document.relativeSourcePath,
@@ -192,7 +192,7 @@ class Store {
             }
             try connection.run(Schema.status.insert(or: .replace,
                                                     Schema.relativePath <- status.relativePath,
-                                                    Schema.contentModificationDate <- status.contentModificationDate,
+                                                    Schema.contentModificationDate <- status.contentModificationDate.millisecondsSinceReferenceDate,
                                                     Schema.importer <- status.importer,
                                                     Schema.fingerprint <- status.fingerprint))
         }
@@ -205,7 +205,7 @@ class Store {
             return nil
         }
         return Status(fileURL: URL(filePath: try status.get(Schema.relativePath), relativeTo: contentURL),
-                      contentModificationDate: try status.get(Schema.contentModificationDate),
+                      contentModificationDate: Date(millisecondsSinceReferenceDate: try status.get(Schema.contentModificationDate)),
                       importer: try status.get(Schema.importer),
                       fingerprint: try status.get(Schema.fingerprint))
     }
@@ -286,7 +286,7 @@ class Store {
                             title: row[Schema.title],
                             metadata: metadata,
                             contents: row[Schema.contents],
-                            contentModificationDate: row[Schema.contentModificationDate],
+                            contentModificationDate: Date(millisecondsSinceReferenceDate: row[Schema.contentModificationDate]),
                             template: row[Schema.template],
                             inlineTemplate: row[Schema.inlineTemplate],
                             relativeSourcePath: row[Schema.relativeSourcePath],


### PR DESCRIPTION
Using full nanosecond precision to track file modification times seems to be broken on Sonoma meaning files always show as modified leading to unnecessary work. This change reduces modification time checks to milliseconds and explicitly uses milliseconds when storing modification times in the intermediate SQLite store.

Nanosecond granularity comparisons did seem to infrequently break pre-Sonoma (see #159) but it's concerning to me the behaviour seems so different on Sonoma.
