### PR TITLE
fix: Support Markdown footnotes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "Dependencies/hummingbird"]
 	path = Dependencies/hummingbird
 	url = git@github.com:jbmorley/hummingbird.git
+[submodule "Dependencies/hoedown"]
+	path = Dependencies/hoedown
+	url = git@github.com:hoedown/hoedown.git

--- a/Package.resolved
+++ b/Package.resolved
@@ -46,15 +46,6 @@
       }
     },
     {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "revision" : "29d9c97e6310b87c4799268eaa2fc76164b2dbd8",
-        "version" : "0.2.0"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -88,24 +79,6 @@
       "state" : {
         "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
         "version" : "1.5.2"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "68b2fed9fb12fb71ac81e537f08bed430b189e35",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "swift-markdownkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/objecthub/swift-markdownkit.git",
-      "state" : {
-        "revision" : "69b44cd50c683527643baa1d78ef71cda40ff65e",
-        "version" : "1.1.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,11 +22,9 @@ let package = Package(
         .package(url: "https://github.com/Frizlab/FSEventsWrapper.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-markdown.git", from: "0.2.0"),
         .package(url: "https://github.com/behrang/YamlSwift.git", from: "3.4.4"),  // Good for unknown?
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),  // Good for known structures
         .package(url: "https://github.com/jwells89/Titlecaser.git", from: "1.0.0"),
-        .package(url: "https://github.com/objecthub/swift-markdownkit.git", from: "1.1.7"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.14.1"),
     ],
@@ -39,14 +37,13 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdFoundation", package: "hummingbird"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Markdown", package: "swift-markdown"),
-                .product(name: "MarkdownKit", package: "swift-markdownkit"),
                 .product(name: "SQLite", package: "SQLite.swift"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 .product(name: "Tilt", package: "Tilt"),
                 .product(name: "Titlecaser", package: "Titlecaser"),
                 .product(name: "Yaml", package: "YamlSwift"),
                 .product(name: "Yams", package: "Yams"),
+                "Hoedown",
             ],
             plugins: [
                 .plugin(name: "EmbedLuaPlugin", package: "LuaSwift")
@@ -59,6 +56,15 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]),
+        .target(
+            name: "Hoedown",
+            dependencies: [],
+            path: "Dependencies/hoedown",
+            sources: [
+                "src"
+            ],
+            publicHeadersPath: "src"
+        )
     ]
 )
 

--- a/Sources/InContextCore/Extensions/String.swift
+++ b/Sources/InContextCore/Extensions/String.swift
@@ -22,8 +22,6 @@
 
 import Foundation
 
-import MarkdownKit
-
 extension String {
 
     private static let schemeRegex = /[a-z]+:/.ignoresCase()
@@ -40,10 +38,21 @@ extension String {
         return prefix + self + suffix
     }
 
+    func safeIdentifier() -> String? {
+        return lowercased()
+            .replacing(/\s+/, with: "-")
+    }
+
     func html() -> String {
-        let markdown = ExtendedMarkdownParser.standard.parse(self)
-        let html = HtmlGenerator.standard.generate(doc: markdown)
-        return html
+        return Hoedown.render(
+            markdown: self,
+            extensions: [
+                .footnotes,
+                .fencedCode,
+                .tables,
+                .strikethrough,
+                .highlight,
+            ]) ?? ""
     }
 
     var hasScheme: Bool {

--- a/Sources/InContextCore/Utilities/Hoedown.swift
+++ b/Sources/InContextCore/Utilities/Hoedown.swift
@@ -1,0 +1,189 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Hoedown
+
+fileprivate extension UnsafeMutablePointer where Pointee == hoedown_buffer {
+
+    var size: size_t {
+        return pointee.size
+    }
+
+    func put(_ string: String) {
+        string.withCString { data in
+            hoedown_buffer_put(self, data, string.count)
+        }
+    }
+
+    func put(format: String, _ arguments: CVarArg...) {
+        put(String(format: format, arguments: arguments))
+    }
+
+    func put(_ buffer: UnsafePointer<hoedown_buffer>) {
+        hoedown_buffer_put(self, buffer.pointee.data, buffer.pointee.size)
+    }
+
+    func asString() -> String? {
+        guard let cString = hoedown_buffer_cstr(self) else {
+            return nil
+        }
+        return String(cString: cString)
+    }
+
+}
+
+fileprivate extension UnsafePointer where Pointee == hoedown_buffer {
+
+    func asString() -> String? {
+        let data = Data(bytes: pointee.data, count: pointee.size)
+        return String(data: data, encoding: .utf8)
+    }
+
+}
+
+class Hoedown {
+
+    struct Extensions : OptionSet {
+
+        let rawValue: UInt32
+
+        init(rawValue: UInt32) {
+            self.rawValue = rawValue
+        }
+
+        private init(_ value: hoedown_extensions) {
+            self.rawValue = value.rawValue
+        }
+
+        // Block-level extensions.
+        static let tables = Extensions(HOEDOWN_EXT_TABLES)
+        static let fencedCode = Extensions(HOEDOWN_EXT_FENCED_CODE)
+        static let footnotes = Extensions(HOEDOWN_EXT_FOOTNOTES)
+
+        // Span-level extensions.
+        static let autolink = Extensions(HOEDOWN_EXT_AUTOLINK)
+        static let strikethrough = Extensions(HOEDOWN_EXT_STRIKETHROUGH)
+        static let underline = Extensions(HOEDOWN_EXT_UNDERLINE)
+        static let highlight = Extensions(HOEDOWN_EXT_HIGHLIGHT)
+        static let quote = Extensions(HOEDOWN_EXT_QUOTE)
+        static let superscript = Extensions(HOEDOWN_EXT_SUPERSCRIPT)
+        static let math = Extensions(HOEDOWN_EXT_MATH)
+
+        // Other flags.
+        static let noIntraEmphasis = Extensions(HOEDOWN_EXT_NO_INTRA_EMPHASIS)
+        static let spaceHeaders = Extensions(HOEDOWN_EXT_SPACE_HEADERS)
+        static let mathExplicit = Extensions(HOEDOWN_EXT_MATH_EXPLICIT)
+
+        // Negative flags.
+        static let disableIndentedCode = Extensions(HOEDOWN_EXT_DISABLE_INDENTED_CODE)
+
+    }
+
+    struct HTMLFlags : OptionSet {
+
+        let rawValue: UInt32
+
+        init(rawValue: UInt32) {
+            self.rawValue = rawValue
+        }
+
+        private init(_ value: hoedown_html_flags) {
+            self.rawValue = value.rawValue
+        }
+
+        static let skipHTML = HTMLFlags(HOEDOWN_HTML_SKIP_HTML)
+        static let escape = HTMLFlags(HOEDOWN_HTML_ESCAPE)
+        static let hardWrap = HTMLFlags(HOEDOWN_HTML_HARD_WRAP)
+        static let useXHTML = HTMLFlags(HOEDOWN_HTML_USE_XHTML)
+    }
+
+    static func render(markdown: String,
+                       flags: Hoedown.HTMLFlags = [],
+                       extensions: Hoedown.Extensions = [],
+                       useSmartyPants: Bool = false,
+                       nestingLevel: Int = 0,
+                       maxNesting: UInt = 16) -> String? {
+
+        guard let renderer = hoedown_html_renderer_new(hoedown_html_flags(flags.rawValue), CInt(nestingLevel)) else {
+            return nil
+        }
+        defer {
+            hoedown_html_renderer_free(renderer)
+        }
+
+        renderer.pointee.header = { buffer, content, level, data in
+
+            let buffer = buffer!
+            let data = data!
+            let state = data.pointee.opaque.assumingMemoryBound(to: hoedown_html_renderer_state.self)
+
+            if buffer.size > 0 {
+                buffer.put("\n")
+            }
+
+            if level <= state.pointee.toc_data.nesting_level {
+                buffer.put(format: "<h%d id=\"toc_%d\">", level, state.pointee.toc_data.header_count)
+                state.pointee.toc_data.header_count += 1
+            } else {
+                buffer.put(format: "<h%d>", level)
+            }
+
+            if let content {
+                if let identifier = content.asString()?.safeIdentifier() {
+                    buffer.put(format: "<a id=\"%@\"></a>", identifier)
+                }
+                buffer.put(content)
+            }
+
+            buffer.put(format: "</h%d>\n", level)
+        }
+
+
+        // Create the renderer.
+        let document = hoedown_document_new(renderer,
+                                            hoedown_extensions(extensions.rawValue),
+                                            Int(maxNesting))
+        defer {
+            hoedown_document_free(document)
+        }
+
+        // Create the processing buffers.
+        guard let outputBuffer = hoedown_buffer_new(16) else { return nil }
+        defer { hoedown_buffer_free(outputBuffer) }
+        guard let sourceBuffer = hoedown_buffer_new(16) else { return nil }
+        defer { hoedown_buffer_free(sourceBuffer) }
+
+        // Optionally pre-process with SmartyPants.
+        if useSmartyPants {
+            hoedown_html_smartypants(sourceBuffer, markdown, markdown.utf8.count);
+        } else {
+            hoedown_buffer_put(sourceBuffer, markdown, markdown.utf8.count);
+        }
+
+        // Process the Markdown.
+        hoedown_document_render(document, outputBuffer, sourceBuffer.pointee.data, sourceBuffer.pointee.size);
+
+        return outputBuffer.asString()
+    }
+
+}

--- a/Tests/InContextTests/Tests/FrontmatterTests.swift
+++ b/Tests/InContextTests/Tests/FrontmatterTests.swift
@@ -41,7 +41,7 @@ queries:
 Here's some **Markdown** content
 """, generateHTML: true)
 
-        XCTAssertEqual(document.content, "<p>Here's some <strong>Markdown</strong> content</p>\n")
+        XCTAssertEqual(document.content, "<p>Here&#39;s some <strong>Markdown</strong> content</p>\n")
         let metadata: [AnyHashable: Any] = ["template": "tags.html",
                                             "title": "Tags",
                                             "category": "pages",

--- a/Tests/InContextTests/Tests/MarkdownTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownTests.swift
@@ -1,0 +1,85 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import InContextCore
+
+class MarkdownTests: XCTestCase {
+
+    func testPlain() {
+        XCTAssertEqual("cheese".html(), "<p>cheese</p>\n")
+    }
+
+    func testMultipleParagraphs() {
+        XCTAssertEqual("""
+Paragraph one
+comprises two lines.
+
+Paragraph two is a single line.
+""".html(), "<p>Paragraph one\ncomprises two lines.</p>\n\n<p>Paragraph two is a single line.</p>\n")
+    }
+
+    func testFootnotes() {
+        XCTAssertEqual("""
+Text with footnote[^1].
+
+[^1]: No, really. This is a footnote.
+""".html(), """
+<p>Text with footnote<sup id="fnref1"><a href="#fn1" rel="footnote">1</a></sup>.</p>
+
+<div class="footnotes">
+<hr>
+<ol>
+
+<li id="fn1">
+<p>No, really. This is a footnote.&nbsp;<a href="#fnref1" rev="footnote">&#8617;</a></p>
+</li>
+
+</ol>
+</div>
+
+""")
+    }
+
+    func testHeaderAnchors() {
+        XCTAssertEqual("""
+# Header 1
+""".html(), """
+<h1><a id="header-1"></a>Header 1</h1>
+
+""")
+
+        XCTAssertEqual("""
+# Header 1
+
+## Header 2
+""".html(), """
+<h1><a id="header-1"></a>Header 1</h1>
+
+<h2><a id="header-2"></a>Header 2</h2>
+
+""")
+    }
+
+}


### PR DESCRIPTION
This change switches over from MarkdownKit to Hoedown and implements custom header rendering behaviour to ensure we still provide support for header anchors.