### PR TITLE
ci: Use consistent artifact upload and download actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
         lfs: true
 
     - name: Download the build artifacts
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v3
       with:
         path: build
 

--- a/notarization-response.json
+++ b/notarization-response.json
@@ -1,1 +1,0 @@
-{"message":"Processing complete","status":"Accepted","id":"cf878885-3705-4404-8227-59a77676ce3d"}


### PR DESCRIPTION
This fixes an issue where download-artifacts@master step was unable to see the artifacts uploaded with upload-artifacts@v3.

This change includes a drive-by fix to remove the transient 'notarization-response.json' which was added in error.