### PR TITLE
fix: Update the copyright year to 2024

### DIFF
--- a/InContext/Helper/Extensions/LogLevel.swift
+++ b/InContext/Helper/Extensions/LogLevel.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Extensions/Publisher.swift
+++ b/InContext/Helper/Extensions/Publisher.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Extensions/URL.swift
+++ b/InContext/Helper/Extensions/URL.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Geocoder.swift
+++ b/InContext/Helper/Geocoder.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/HelperApp.swift
+++ b/InContext/Helper/HelperApp.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/HelperError.swift
+++ b/InContext/Helper/HelperError.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/ApplicationModel.swift
+++ b/InContext/Helper/Model/ApplicationModel.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/Event.swift
+++ b/InContext/Helper/Model/Event.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/HelperSession.swift
+++ b/InContext/Helper/Model/HelperSession.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/HelperSessionTask.swift
+++ b/InContext/Helper/Model/HelperSessionTask.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/HelperTracker.swift
+++ b/InContext/Helper/Model/HelperTracker.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/Settings.swift
+++ b/InContext/Helper/Model/Settings.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Model/SiteModel.swift
+++ b/InContext/Helper/Model/SiteModel.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/ActionsMenu.swift
+++ b/InContext/Helper/Views/ActionsMenu.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/FavoritesMenu.swift
+++ b/InContext/Helper/Views/FavoritesMenu.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/LogView.swift
+++ b/InContext/Helper/Views/LogView.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/LogWindow.swift
+++ b/InContext/Helper/Views/LogWindow.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/SessionFooter.swift
+++ b/InContext/Helper/Views/SessionFooter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/SessionView.swift
+++ b/InContext/Helper/Views/SessionView.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/SettingsMenu.swift
+++ b/InContext/Helper/Views/SettingsMenu.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/SiteList.swift
+++ b/InContext/Helper/Views/SiteList.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/SiteMenu.swift
+++ b/InContext/Helper/Views/SiteMenu.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/Helper/Views/TaskRow.swift
+++ b/InContext/Helper/Views/TaskRow.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/HelperTests/HelperTests.swift
+++ b/InContext/HelperTests/HelperTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/HelperUITests/HelperUITests.swift
+++ b/InContext/HelperUITests/HelperUITests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/HelperUITests/HelperUITestsLaunchTests.swift
+++ b/InContext/HelperUITests/HelperUITestsLaunchTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Build.swift
+++ b/InContext/InContext/Commands/Build.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Clean.swift
+++ b/InContext/InContext/Commands/Clean.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Command.swift
+++ b/InContext/InContext/Commands/Command.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Options.swift
+++ b/InContext/InContext/Commands/Options.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Run.swift
+++ b/InContext/InContext/Commands/Run.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Commands/Serve.swift
+++ b/InContext/InContext/Commands/Serve.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Info.plist
+++ b/InContext/InContext/Info.plist
@@ -13,6 +13,6 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2016-2023 Jason Morley</string>
+	<string>Copyright © 2016-2016-2024 Jason Morley</string>
 </dict>
 </plist>

--- a/InContext/InContext/Model/LoggingSession.swift
+++ b/InContext/InContext/Model/LoggingSession.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Model/LoggingTask.swift
+++ b/InContext/InContext/Model/LoggingTask.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/InContext/InContext/Model/LoggingTracker.swift
+++ b/InContext/InContext/Model/LoggingTracker.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jason Morley
+Copyright (c) 2016-2024 Jason Morley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Jason Morley
+# Copyright (c) 2016-2024 Jason Morley
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023 Jason Morley
+# Copyright (c) 2016-2024 Jason Morley
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023 Jason Morley
+# Copyright (c) 2016-2024 Jason Morley
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Scripts/gh-release.sh
+++ b/Scripts/gh-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 InSeven Limited
+# Copyright (c) 2016-2024 Jason Morley
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+# Copyright (c) 2016-2024 Jason Morley
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 set -e
 set -o pipefail
 set -u

--- a/Sources/InContextCore/ActionRunner.swift
+++ b/Sources/InContextCore/ActionRunner.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/AnyHandler.swift
+++ b/Sources/InContextCore/AnyHandler.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Asset.swift
+++ b/Sources/InContextCore/Asset.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Builder.swift
+++ b/Sources/InContextCore/Builder.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Contexts/DocumentContext.swift
+++ b/Sources/InContextCore/Contexts/DocumentContext.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Document.swift
+++ b/Sources/InContextCore/Document.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/EvaluationContext.swift
+++ b/Sources/InContextCore/EvaluationContext.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Array.swift
+++ b/Sources/InContextCore/Extensions/Array.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Bool.swift
+++ b/Sources/InContextCore/Extensions/Bool.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Date.swift
+++ b/Sources/InContextCore/Extensions/Date.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Dictionary.swift
+++ b/Sources/InContextCore/Extensions/Dictionary.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Double.swift
+++ b/Sources/InContextCore/Extensions/Double.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/FileManager.swift
+++ b/Sources/InContextCore/Extensions/FileManager.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Float.swift
+++ b/Sources/InContextCore/Extensions/Float.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Int.swift
+++ b/Sources/InContextCore/Extensions/Int.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/KeyedDecodingContainer.swift
+++ b/Sources/InContextCore/Extensions/KeyedDecodingContainer.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/String.swift
+++ b/Sources/InContextCore/Extensions/String.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/StringProtocol.swift
+++ b/Sources/InContextCore/Extensions/StringProtocol.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Task.swift
+++ b/Sources/InContextCore/Extensions/Task.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/URL.swift
+++ b/Sources/InContextCore/Extensions/URL.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/UTType.swift
+++ b/Sources/InContextCore/Extensions/UTType.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/UnkeyedDecodingContainer.swift
+++ b/Sources/InContextCore/Extensions/UnkeyedDecodingContainer.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/UnknownCodingKeys.swift
+++ b/Sources/InContextCore/Extensions/UnknownCodingKeys.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Extensions/Yaml.swift
+++ b/Sources/InContextCore/Extensions/Yaml.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/File.swift
+++ b/Sources/InContextCore/File.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Formatters.swift
+++ b/Sources/InContextCore/Formatters.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/FrontmatterDocument.swift
+++ b/Sources/InContextCore/FrontmatterDocument.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Handler.swift
+++ b/Sources/InContextCore/Handler.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/ImageTransform.swift
+++ b/Sources/InContextCore/ImageTransform.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/CopyImporter.swift
+++ b/Sources/InContextCore/Importers/CopyImporter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/EmptySettings.swift
+++ b/Sources/InContextCore/Importers/EmptySettings.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/IgnoreImporter.swift
+++ b/Sources/InContextCore/Importers/IgnoreImporter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/Importer.swift
+++ b/Sources/InContextCore/Importers/Importer.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/MarkdownImporter.swift
+++ b/Sources/InContextCore/Importers/MarkdownImporter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/InContextError.swift
+++ b/Sources/InContextCore/InContextError.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Metadata.swift
+++ b/Sources/InContextCore/Metadata.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Protocols/Finishable.swift
+++ b/Sources/InContextCore/Protocols/Finishable.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Protocols/Logger.swift
+++ b/Sources/InContextCore/Protocols/Logger.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Protocols/Session.swift
+++ b/Sources/InContextCore/Protocols/Session.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Protocols/SessionTask.swift
+++ b/Sources/InContextCore/Protocols/SessionTask.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Protocols/Tracker.swift
+++ b/Sources/InContextCore/Protocols/Tracker.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/QueryStatus.swift
+++ b/Sources/InContextCore/QueryStatus.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/RenderStatus.swift
+++ b/Sources/InContextCore/RenderStatus.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/RenderTracker.swift
+++ b/Sources/InContextCore/RenderTracker.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Renderers/RenderManager.swift
+++ b/Sources/InContextCore/Renderers/RenderManager.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Renderers/RenderResult.swift
+++ b/Sources/InContextCore/Renderers/RenderResult.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Renderers/RendererInstance.swift
+++ b/Sources/InContextCore/Renderers/RendererInstance.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Renderers/TiltRenderer.swift
+++ b/Sources/InContextCore/Renderers/TiltRenderer.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Server.swift
+++ b/Sources/InContextCore/Server.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Settings.swift
+++ b/Sources/InContextCore/Settings.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Site.swift
+++ b/Sources/InContextCore/Site.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Status.swift
+++ b/Sources/InContextCore/Status.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Store/QueryDescription.swift
+++ b/Sources/InContextCore/Store/QueryDescription.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Store/Store.swift
+++ b/Sources/InContextCore/Store/Store.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/TemplateCache.swift
+++ b/Sources/InContextCore/TemplateCache.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/TemplateDetails.swift
+++ b/Sources/InContextCore/TemplateDetails.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/TemplateIdentifier.swift
+++ b/Sources/InContextCore/TemplateIdentifier.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/TemplateRenderStatus.swift
+++ b/Sources/InContextCore/TemplateRenderStatus.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Transforms/ImageDocumentTransform.swift
+++ b/Sources/InContextCore/Transforms/ImageDocumentTransform.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Transforms/RelativeSourceTransform.swift
+++ b/Sources/InContextCore/Transforms/RelativeSourceTransform.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Transforms/Transformer.swift
+++ b/Sources/InContextCore/Transforms/Transformer.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/ArgumentProvider.swift
+++ b/Sources/InContextCore/Utilities/ArgumentProvider.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/BasenameDetails.swift
+++ b/Sources/InContextCore/Utilities/BasenameDetails.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Cache.swift
+++ b/Sources/InContextCore/Utilities/Cache.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Callable.swift
+++ b/Sources/InContextCore/Utilities/Callable.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/CallablesBuilder.swift
+++ b/Sources/InContextCore/Utilities/CallablesBuilder.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Candidates.swift
+++ b/Sources/InContextCore/Utilities/Candidates.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/ChangeObserver.swift
+++ b/Sources/InContextCore/Utilities/ChangeObserver.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/ConcurrentBox.swift
+++ b/Sources/InContextCore/Utilities/ConcurrentBox.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/EXIF.swift
+++ b/Sources/InContextCore/Utilities/EXIF.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Fingerprint.swift
+++ b/Sources/InContextCore/Utilities/Fingerprint.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Fingerprintable.swift
+++ b/Sources/InContextCore/Utilities/Fingerprintable.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Function.swift
+++ b/Sources/InContextCore/Utilities/Function.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Hoedown.swift
+++ b/Sources/InContextCore/Utilities/Hoedown.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/ParentIterator.swift
+++ b/Sources/InContextCore/Utilities/ParentIterator.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/Size.swift
+++ b/Sources/InContextCore/Utilities/Size.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/InContextCore/Utilities/TaskRunner.swift
+++ b/Sources/InContextCore/Utilities/TaskRunner.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Bundle.swift
+++ b/Tests/InContextTests/Extensions/Bundle.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Date.swift
+++ b/Tests/InContextTests/Extensions/Date.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Document.swift
+++ b/Tests/InContextTests/Extensions/Document.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Status.swift
+++ b/Tests/InContextTests/Extensions/Status.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Store.swift
+++ b/Tests/InContextTests/Extensions/Store.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/Utilities.swift
+++ b/Tests/InContextTests/Extensions/Utilities.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Extensions/XCTest.swift
+++ b/Tests/InContextTests/Extensions/XCTest.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/BasenameDetailsTests.swift
+++ b/Tests/InContextTests/Tests/BasenameDetailsTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/ConcurrentBoxTests.swift
+++ b/Tests/InContextTests/Tests/ConcurrentBoxTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/FrontmatterTests.swift
+++ b/Tests/InContextTests/Tests/FrontmatterTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/HandlerTests.swift
+++ b/Tests/InContextTests/Tests/HandlerTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/MarkdownImporterTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownImporterTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/MarkdownTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/StoreTests.swift
+++ b/Tests/InContextTests/Tests/StoreTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/TemplateIdentifierTests.swift
+++ b/Tests/InContextTests/Tests/TemplateIdentifierTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/UtilityTests.swift
+++ b/Tests/InContextTests/Tests/UtilityTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Tests/VideoImporterTests.swift
+++ b/Tests/InContextTests/Tests/VideoImporterTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Utilities/ContentTestCase.swift
+++ b/Tests/InContextTests/Utilities/ContentTestCase.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Utilities/SourceDirectory.swift
+++ b/Tests/InContextTests/Utilities/SourceDirectory.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/InContextTests/Utilities/TestError.swift
+++ b/Tests/InContextTests/Utilities/TestError.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023 Jason Morley
+// Copyright (c) 2016-2024 Jason Morley
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -1,5 +1,5 @@
 <footer>
-    <p>Copyright &copy; 2016-2023 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
+    <p>Copyright &copy; 2016-2024 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
     <p>Built with InContext and Tilt</p>
     <p><a href="https://github.com/inseven/incontext/blob/main/docs/content/{{ document.sourcePath }}">View Source</a></p>
 </footer>


### PR DESCRIPTION
This also updates the copyright period to include the original InContext code and design (2016-2024).