### PR TITLE
refactor: Adopt the new cross-platform `PlatformSupport` module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,8 @@ let package = Package(
         .target(
             name: "InContextCore",
             dependencies: [
+                "PlatformSupport",
+                "Hoedown",
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "FSEventsWrapper", package: "FSEventsWrapper"),
                 .product(name: "Hummingbird", package: "hummingbird"),
@@ -57,7 +59,6 @@ let package = Package(
                 .product(name: "Titlecaser", package: "Titlecaser"),
                 .product(name: "Yaml", package: "YamlSwift"),
                 .product(name: "Yams", package: "Yams"),
-                "Hoedown",
             ],
             plugins: [
                 .plugin(name: "EmbedLuaPlugin", package: "LuaSwift")

--- a/Sources/InContextCore/Extensions/Date.swift
+++ b/Sources/InContextCore/Extensions/Date.swift
@@ -22,6 +22,8 @@
 
 import Foundation
 
+import PlatformSupport
+
 extension Date: EvaluationContext {
 
     var millisecondsSinceReferenceDate: Int {

--- a/Sources/InContextCore/Extensions/URL.swift
+++ b/Sources/InContextCore/Extensions/URL.swift
@@ -21,10 +21,11 @@
 // SOFTWARE.
 
 import Foundation
-import UniformTypeIdentifiers
 
 import Titlecaser
 import RegexBuilder
+
+import PlatformSupport
 
 extension URL {
 

--- a/Sources/InContextCore/ImageTransform.swift
+++ b/Sources/InContextCore/ImageTransform.swift
@@ -21,7 +21,8 @@
 // SOFTWARE.
 
 import Foundation
-import UniformTypeIdentifiers
+
+import PlatformSupport
 
 struct ImageTransform {
 

--- a/Sources/InContextCore/Renderers/RenderManager.swift
+++ b/Sources/InContextCore/Renderers/RenderManager.swift
@@ -24,6 +24,8 @@ import Foundation
 
 import SwiftSoup
 
+import PlatformSupport
+
 class RenderManager {
 
     private let templateCache: TemplateCache

--- a/Sources/InContextCore/Site.swift
+++ b/Sources/InContextCore/Site.swift
@@ -21,9 +21,10 @@
 // SOFTWARE.
 
 import Foundation
-import UniformTypeIdentifiers
 
 import Yams
+
+import PlatformSupport
 
 public struct Site {
 

--- a/Sources/InContextCore/TemplateIdentifier.swift
+++ b/Sources/InContextCore/TemplateIdentifier.swift
@@ -23,7 +23,8 @@
 import Foundation
 
 import SQLite
-import UniformTypeIdentifiers
+
+import PlatformSupport
 
 class TemplateIdentifier: RawRepresentable, Equatable, Codable, Hashable, CustomStringConvertible {
 

--- a/Sources/PlatformSupport/PlatformSupport.swift
+++ b/Sources/PlatformSupport/PlatformSupport.swift
@@ -25,9 +25,11 @@
 // will pull in all platform-specific code.
 
 #if os(macOS)
-import PlatformSupportMacOS
+@_exported import PlatformSupportMacOS
+@_exported import UniformTypeIdentifiers
 #endif
 
 #if os(Linux)
-import PlatformSupportLinux
+@_exported import PlatformSupportLinux
 #endif
+

--- a/Tests/InContextTests/Extensions/Date.swift
+++ b/Tests/InContextTests/Extensions/Date.swift
@@ -22,6 +22,8 @@
 
 import Foundation
 
+import InContextCore
+
 extension Date {
 
     init(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) {


### PR DESCRIPTION
This switches from importing `UniformTypeIdentifiers` to `PlatformSupport` which will provide a shim replacement for `UTType` on Linux.