### PR TITLE
refactor: Rename the incontext package name in the Xcode project

### DIFF
--- a/InContext/InContext.xcodeproj/project.pbxproj
+++ b/InContext/InContext.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		D8850A222B84260D00E17977 /* luaswift-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "luaswift-license"; sourceTree = "<group>"; };
 		D8850A242B8426B900E17977 /* sqliteswift-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sqliteswift-license"; sourceTree = "<group>"; };
 		D890630A2A98293A0001A8E2 /* incontext */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = incontext; sourceTree = BUILT_PRODUCTS_DIR; };
-		D89063152A9829500001A8E2 /* incontext-waialua */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "incontext-waialua"; path = ..; sourceTree = "<group>"; };
+		D89063152A9829500001A8E2 /* incontext */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "incontext"; path = ..; sourceTree = "<group>"; };
 		D8920F192AB2AB4B00137912 /* diligence */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = diligence; path = ../Dependencies/diligence; sourceTree = "<group>"; };
 		D8A739B32AA660F400946EED /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
 		D8A739B52AA6611E00946EED /* LogWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogWindow.swift; sourceTree = "<group>"; };
@@ -316,7 +316,7 @@
 		D89063142A9829500001A8E2 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				D89063152A9829500001A8E2 /* incontext-waialua */,
+				D89063152A9829500001A8E2 /* incontext */,
 				D8920F192AB2AB4B00137912 /* diligence */,
 			);
 			name = Packages;

--- a/docs/templates/navigation.html
+++ b/docs/templates/navigation.html
@@ -4,7 +4,7 @@
             <li><a href="/">InContext</a></li>
             <li><a href="/docs/">Docs</a></li>
             <li><a href="https://github.com/inseven/incontext/releases/latest" target="_blank">Latest Release</a></li>
-            <li><a href="https://github.com/inseven/incontext-waialua" target="_blank">GitHub</a></li>
+            <li><a href="https://github.com/inseven/incontext" target="_blank">GitHub</a></li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
This somehow kept the 'incontext-waialua' name from the old repository.