### PR TITLE
chore: Remove unused CNAME file

### DIFF
--- a/docs/content/CNAME
+++ b/docs/content/CNAME
@@ -1,1 +1,0 @@
-incontext.app


### PR DESCRIPTION
This is a legacy from earlier GitHub Pages hosting.